### PR TITLE
Move payload to bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ version = "0.0.7"
 dependencies = [
  "anyhow",
  "bitflags",
+ "bytes",
  "chrono",
  "crc",
  "crc32c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ once_cell = "1.21.3"
 zerocopy = { version = "0.8.26", features = ["derive"] }
 serial_test = "3.2.0"
 tokio-util = "0.7.16"
+bytes = "1.10.1"
 
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,10 @@ zerocopy = { version = "0.8.26", features = ["derive"] }
 serial_test = "3.2.0"
 tokio-util = "0.7.16"
 bytes = "1.10.1"
+#hat = { version = "0.3", optional = true }
 
+#[features]
+#mem-prof-dhat = ["dep:dhat"]
 
 [workspace]
 members = ["."]

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -175,7 +175,7 @@ impl ClientConnection {
     /// Helper to serialize and write a PDU to the socket.
     async fn write(
         &self,
-        mut req: impl ToBytes<Header = [u8; HEADER_LEN]> + fmt::Debug,
+        mut req: impl ToBytes<Header = [u8; HEADER_LEN], Body = Bytes> + fmt::Debug,
     ) -> Result<()> {
         if self.cancel.is_cancelled() {
             bail!("cancelled");
@@ -209,7 +209,7 @@ impl ClientConnection {
     pub async fn send_request(
         &self,
         initiator_task_tag: u32,
-        req: impl ToBytes<Header = [u8; HEADER_LEN]> + Debug,
+        req: impl ToBytes<Header = [u8; HEADER_LEN], Body = Bytes> + Debug,
     ) -> Result<()> {
         if self.cancel.is_cancelled() {
             bail!("cancelled");

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     models::{
         common::{BasicHeaderSegment, HEADER_LEN, SendingData},
-        data_fromat::{PDUWithData, ZeroCopyType},
+        data_fromat::{PduResponse, ZeroCopyType},
         nop::{request::NopOutRequest, response::NopInResponse},
         parse::Pdu,
     },
@@ -236,7 +236,7 @@ impl ClientConnection {
     pub async fn read_response_raw<T: BasicHeaderSegment + Debug>(
         &self,
         initiator_task_tag: u32,
-    ) -> Result<(PDUWithData<T>, Bytes)> {
+    ) -> Result<(PduResponse<T>, Bytes)> {
         let mut rx = self
             .reciver
             .remove(&initiator_task_tag)
@@ -262,7 +262,7 @@ impl ClientConnection {
             let _ = self.reciver.insert(initiator_task_tag, rx);
         }
 
-        let pdu = PDUWithData::<T>::from_header_slice(hdr_arr, &self.cfg);
+        let pdu = PduResponse::<T>::from_header_slice(hdr_arr, &self.cfg);
 
         Ok((pdu, payload))
     }
@@ -272,7 +272,7 @@ impl ClientConnection {
     >(
         &self,
         initiator_task_tag: u32,
-    ) -> Result<PDUWithData<T>> {
+    ) -> Result<PduResponse<T>> {
         let (mut pdu, data) = self.read_response_raw(initiator_task_tag).await?;
 
         let header: &T = pdu.header_view()?;
@@ -403,7 +403,7 @@ impl ClientConnection {
         hdr: [u8; HEADER_LEN],
         payload: Bytes,
     ) -> bool {
-        let mut pdu = PDUWithData::<NopInResponse>::from_header_slice(hdr, &self.cfg);
+        let mut pdu = PduResponse::<NopInResponse>::from_header_slice(hdr, &self.cfg);
 
         let (hd, dd, ttt) = {
             let header = match pdu.header_view() {

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -4,10 +4,9 @@
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
+use bytes::Bytes;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
-
-use crate::models::common::HEADER_LEN;
 
 pub(super) async fn io_with_timeout<F, T>(
     label: &'static str,
@@ -30,8 +29,10 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RawPdu {
-    pub last_hdr_with_updated_data: [u8; HEADER_LEN],
-    pub data: Vec<u8>,
+    /// Exactly 48 bytes (BHS)
+    pub header: Bytes,
+    /// BODY (AHS + pad + [HD?] + DATA + pad + [DD?])
+    pub payload: Bytes,
 }

--- a/src/client/pdu_connection.rs
+++ b/src/client/pdu_connection.rs
@@ -13,6 +13,7 @@ pub trait ToBytes: Sized {
     // The fixed length of the PDU header in bytes.
     // rust now don`t support compile time array length
     type Header: AsRef<[u8]>;
+    type Body: AsRef<[u8]>;
 
     /// Consume the PDU builder or object and produce:
     /// - A fixed-size array of `HEADER_LEN` bytes representing the PDU header.
@@ -23,7 +24,7 @@ pub trait ToBytes: Sized {
         max_recv_data_segment_length: usize,
         enable_header_digest: bool,
         enable_data_digest: bool,
-    ) -> Result<(Self::Header, Vec<u8>)>;
+    ) -> Result<(Self::Header, Self::Body)>;
 }
 
 /// Trait for deserializing a full PDU from raw bytes.
@@ -42,6 +43,7 @@ pub trait FromBytes: Sized + BasicHeaderSegment {
 impl<B> ToBytes for B
 where B: Builder
 {
+    type Body = B::Body;
     type Header = B::Header;
 
     fn to_bytes(
@@ -49,7 +51,7 @@ where B: Builder
         max_recv_data_segment_length: usize,
         enable_header_digest: bool,
         enable_data_digest: bool,
-    ) -> Result<(Self::Header, Vec<u8>)> {
+    ) -> Result<(Self::Header, Self::Body)> {
         self.build(
             max_recv_data_segment_length,
             enable_header_digest,

--- a/src/handlers/text_request.rs
+++ b/src/handlers/text_request.rs
@@ -9,7 +9,7 @@ use crate::{
     client::client::ClientConnection,
     models::{
         common::{BasicHeaderSegment, Builder, HEADER_LEN},
-        data_fromat::PDUWithData,
+        data_fromat::{PduRequest, PduResponse},
         text::{
             request::{TextRequest, TextRequestBuilder},
             response::TextResponse,
@@ -26,7 +26,7 @@ pub async fn send_text(
     target_task_tag: u32,
     cmd_sn: &AtomicU32,
     exp_stat_sn: &AtomicU32,
-) -> Result<PDUWithData<TextResponse>> {
+) -> Result<PduResponse<TextResponse>> {
     let sn = cmd_sn.load(Ordering::SeqCst);
     let esn = exp_stat_sn.load(Ordering::SeqCst);
     let itt = initiator_task_tag.fetch_add(1, Ordering::SeqCst);
@@ -41,8 +41,7 @@ pub async fn send_text(
     let mut buf = [0u8; HEADER_LEN];
     header.header.to_bhs_bytes(&mut buf)?;
 
-    let mut builder: PDUWithData<TextRequest> =
-        PDUWithData::from_header_slice(buf, &conn.cfg);
+    let mut builder = PduRequest::<TextRequest>::new_request(buf, &conn.cfg);
 
     builder.append_data(b"X-Ping=1\0".as_slice());
 

--- a/src/handlers/text_request.rs
+++ b/src/handlers/text_request.rs
@@ -41,9 +41,10 @@ pub async fn send_text(
     let mut buf = [0u8; HEADER_LEN];
     header.header.to_bhs_bytes(&mut buf)?;
 
-    let mut builder: PDUWithData<TextRequest> = PDUWithData::from_header_slice(buf);
+    let mut builder: PDUWithData<TextRequest> =
+        PDUWithData::from_header_slice(buf, &conn.cfg);
 
-    builder.append_data(b"X-Ping=1\0".to_vec());
+    builder.append_data(b"X-Ping=1\0".as_slice());
 
     /*info!(
         "TextRequest hdr={:?} data={}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,16 @@ fn choose_lba_safely(max_lba: u64, need_blocks: u64) -> Result<u32> {
     Ok(lba as u32)
 }
 
+/*#[cfg(feature = "mem-prof-dhat")]
+#[global_allocator]
+static DHAT_ALLOC: dhat::Alloc = dhat::Alloc;*/
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let _init_logger = init_logger("tests/config_logger.yaml")?;
+
+    /*#[cfg(feature = "mem-prof-dhat")]
+    let _profiler = dhat::Profiler::new_heap();*/
 
     // Load config
     let cfg: Arc<Config> = Arc::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 fn fill_pattern(buf: &mut [u8], blk_sz: usize, lba_start: u64) {
-    assert!(blk_sz > 0 && buf.len() % blk_sz == 0);
+    assert!(blk_sz > 0 && buf.len().is_multiple_of(blk_sz));
     for (i, chunk) in buf.chunks_exact(blk_sz).enumerate() {
         let v = (((lba_start as usize) + i) as u8) ^ 0xA5;
         unsafe { std::ptr::write_bytes(chunk.as_ptr() as *mut u8, v, blk_sz) }

--- a/src/models/command/response.rs
+++ b/src/models/command/response.rs
@@ -60,6 +60,34 @@ impl ScsiCommandResponse {
         }
         Ok(hdr)
     }
+
+    #[inline]
+    pub fn residual_valid(&self) -> bool {
+        self.flags.u_big() || self.flags.o_big()
+    }
+
+    #[inline]
+    pub fn residual_effective(&self) -> u32 {
+        if self.residual_valid() {
+            self.residual_count.get()
+        } else {
+            0
+        }
+    }
+
+    #[inline]
+    pub fn bidi_read_residual_valid(&self) -> bool {
+        self.flags.u_small() || self.flags.o_small()
+    }
+
+    #[inline]
+    pub fn bidi_read_residual_effective(&self) -> u32 {
+        if self.bidi_read_residual_valid() {
+            self.bidirectional_read_residual_count.get()
+        } else {
+            0
+        }
+    }
 }
 
 impl SendingData for ScsiCommandResponse {

--- a/src/models/command/zero_copy.rs
+++ b/src/models/command/zero_copy.rs
@@ -452,10 +452,10 @@ impl fmt::Debug for RawScsiCmdRespFlags {
         if self.u_small() {
             write!(f, "U_SMALL|")?;
         }
-        if self.u_small() {
+        if self.o_big() {
             write!(f, "O_BIG|")?;
         }
-        if self.u_small() {
+        if self.u_big() {
             write!(f, "U_BIG|")?;
         }
         write!(f, "valid:{} }}", &valid)

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -183,7 +183,7 @@ pub trait Builder: Sized {
 
     /// Append raw bytes to the **Data-Segment** and update the
     /// `DataSegmentLength` field inside the owned header.
-    fn append_data(&mut self, more: Vec<u8>);
+    fn append_data(&mut self, more: &[u8]);
 
     /// Finish the builder and produce one or more ready-to-send
     /// `(header_bytes, data_bytes)` frames.

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -180,6 +180,7 @@ impl<T: BasicHeaderSegment> BasicHeaderSegment for &mut T {
 pub trait Builder: Sized {
     /// The concrete buffer type used to return the encoded header.
     type Header: AsRef<[u8]>;
+    type Body: AsRef<[u8]>;
 
     /// Append raw bytes to the **Data-Segment** and update the
     /// `DataSegmentLength` field inside the owned header.
@@ -195,5 +196,5 @@ pub trait Builder: Sized {
         max_recv_data_segment_length: usize,
         enable_header_digest: bool,
         enable_data_digest: bool,
-    ) -> Result<(Self::Header, Vec<u8>)>;
+    ) -> Result<(Self::Header, Self::Body)>;
 }

--- a/src/models/data/response.rs
+++ b/src/models/data/response.rs
@@ -51,6 +51,20 @@ impl ScsiDataIn {
         }
     }
 
+    #[inline]
+    pub fn residual_valid(&self) -> bool {
+        self.flags.u() || self.flags.o()
+    }
+
+    #[inline]
+    pub fn residual_effective(&self) -> u32 {
+        if self.residual_valid() {
+            self.residual_count.get()
+        } else {
+            0
+        }
+    }
+
     /// Sets/clears SCSI status and enforces `S ⇒ F`.
     #[inline]
     pub fn set_scsi_status(&mut self, st: Option<ScsiStatus>) {

--- a/src/models/data_fromat.rs
+++ b/src/models/data_fromat.rs
@@ -68,7 +68,8 @@ pub struct PDUWithData<T> {
 }
 
 impl<T> Builder for PDUWithData<T>
-where T: BasicHeaderSegment + SendingData + FromBytes + ZeroCopyType
+where
+    T: BasicHeaderSegment + SendingData + FromBytes + ZeroCopyType,
 {
     type Header = [u8; HEADER_LEN];
 
@@ -173,7 +174,9 @@ impl<T> PDUWithData<T> {
     }
 
     pub fn rebind_pdu<U>(self) -> anyhow::Result<PDUWithData<U>>
-    where U: BasicHeaderSegment {
+    where
+        U: BasicHeaderSegment,
+    {
         Ok(PDUWithData::<U> {
             header_buf: self.header_buf,
             aditional_heder: self.aditional_heder,
@@ -186,7 +189,8 @@ impl<T> PDUWithData<T> {
 }
 
 impl<T> PDUWithData<T>
-where T: BasicHeaderSegment + FromBytes + ZeroCopyType
+where
+    T: BasicHeaderSegment + FromBytes + ZeroCopyType,
 {
     /// Header view (`&T`) backed by `self.header_buf`.
     #[inline]
@@ -350,7 +354,8 @@ impl<'a> fmt::Debug for HexPreview<'a> {
 }
 
 impl<T> fmt::Debug for PDUWithData<T>
-where T: BasicHeaderSegment + SendingData + FromBytes + fmt::Debug + ZeroCopyType
+where
+    T: BasicHeaderSegment + SendingData + FromBytes + fmt::Debug + ZeroCopyType,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut ds = f.debug_struct("PDUWithData");

--- a/src/state_machine/login/common.rs
+++ b/src/state_machine/login/common.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use crate::{
     client::client::ClientConnection,
     models::{
-        common::HEADER_LEN, data_fromat::PDUWithData, login::response::LoginResponse,
+        common::HEADER_LEN, data_fromat::PduResponse, login::response::LoginResponse,
     },
     state_machine::{
         common::{StateMachine, StateMachineCtx, Transition},
@@ -29,7 +29,7 @@ pub struct LoginCtx<'a> {
     pub itt: u32,
     pub buf: [u8; HEADER_LEN],
 
-    pub last_response: Option<PDUWithData<LoginResponse>>,
+    pub last_response: Option<PduResponse<LoginResponse>>,
 
     state: Option<LoginStates>,
 }
@@ -67,7 +67,7 @@ impl<'a> LoginCtx<'a> {
         }
     }
 
-    pub fn validate_last_response_pdu(&self) -> Result<&PDUWithData<LoginResponse>> {
+    pub fn validate_last_response_pdu(&self) -> Result<&PduResponse<LoginResponse>> {
         match &self.last_response {
             Some(l) => Ok(l),
             None => Err(anyhow!("no last response in ctx")),
@@ -88,13 +88,13 @@ pub enum LoginStates {
     ChapOpToFull(ChapOpToFull),
 }
 
-impl<'ctx> StateMachineCtx<LoginCtx<'ctx>, PDUWithData<LoginResponse>>
+impl<'ctx> StateMachineCtx<LoginCtx<'ctx>, PduResponse<LoginResponse>>
     for LoginCtx<'ctx>
 {
     async fn execute(
         &mut self,
         _cancel: &CancellationToken,
-    ) -> Result<PDUWithData<LoginResponse>> {
+    ) -> Result<PduResponse<LoginResponse>> {
         debug!("Loop login");
         loop {
             let state = self.state.take().context("state must be set LoginCtx")?;

--- a/src/state_machine/login/login_chap.rs
+++ b/src/state_machine/login/login_chap.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     models::{
         common::Builder,
-        data_fromat::PDUWithData,
+        data_fromat::PduRequest,
         login::{
             common::Stage,
             request::{LoginRequest, LoginRequestBuilder},
@@ -99,8 +99,7 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapSecurity {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu =
-                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            let mut pdu = PduRequest::<LoginRequest>::new_request(ctx.buf, &ctx.conn.cfg);
             pdu.append_data(login_keys_security(&ctx.conn.cfg).as_slice());
 
             match ctx.conn.send_request(ctx.itt, pdu).await {
@@ -153,8 +152,7 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapA {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu =
-                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            let mut pdu = PduRequest::<LoginRequest>::new_request(ctx.buf, &ctx.conn.cfg);
             pdu.append_data(b"CHAP_A=5\x00".as_slice());
 
             match ctx.conn.send_request(itt, pdu).await {
@@ -232,8 +230,7 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapAnswer {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu =
-                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            let mut pdu = PduRequest::<LoginRequest>::new_request(ctx.buf, &ctx.conn.cfg);
             pdu.append_data(login_keys_chap_response(user, &chap_r).as_slice());
 
             if let Err(e) = ctx.conn.send_request(itt, pdu).await {
@@ -286,8 +283,7 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapOpToFull {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu =
-                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            let mut pdu = PduRequest::<LoginRequest>::new_request(ctx.buf, &ctx.conn.cfg);
             pdu.append_data(login_keys_operational(&ctx.conn.cfg).as_slice());
 
             match ctx.conn.send_request(itt, pdu).await {

--- a/src/state_machine/login/login_chap.rs
+++ b/src/state_machine/login/login_chap.rs
@@ -99,8 +99,9 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapSecurity {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu = PDUWithData::<LoginRequest>::from_header_slice(ctx.buf);
-            pdu.append_data(login_keys_security(&ctx.conn.cfg));
+            let mut pdu =
+                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            pdu.append_data(login_keys_security(&ctx.conn.cfg).as_slice());
 
             match ctx.conn.send_request(ctx.itt, pdu).await {
                 Err(e) => Transition::Done(Err(e)),
@@ -152,8 +153,9 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapA {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu = PDUWithData::<LoginRequest>::from_header_slice(ctx.buf);
-            pdu.append_data(b"CHAP_A=5\x00".to_vec());
+            let mut pdu =
+                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            pdu.append_data(b"CHAP_A=5\x00".as_slice());
 
             match ctx.conn.send_request(itt, pdu).await {
                 Err(e) => Transition::Done(Err(e)),
@@ -192,7 +194,12 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapAnswer {
                     Err(e) => return Transition::Done(Err(e)),
                 };
 
-                let (id, chal) = match parse_chap_challenge(&last.data) {
+                let data = match last.data() {
+                    Ok(data) => data,
+                    Err(e) => return Transition::Done(Err(e)),
+                };
+
+                let (id, chal) = match parse_chap_challenge(data) {
                     Ok(v) => v,
                     Err(e) => return Transition::Done(Err(e)),
                 };
@@ -225,8 +232,9 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapAnswer {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu = PDUWithData::<LoginRequest>::from_header_slice(ctx.buf);
-            pdu.append_data(login_keys_chap_response(user, &chap_r));
+            let mut pdu =
+                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            pdu.append_data(login_keys_chap_response(user, &chap_r).as_slice());
 
             if let Err(e) = ctx.conn.send_request(itt, pdu).await {
                 return Transition::Done(Err(e));
@@ -278,8 +286,9 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for ChapOpToFull {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu = PDUWithData::<LoginRequest>::from_header_slice(ctx.buf);
-            pdu.append_data(login_keys_operational(&ctx.conn.cfg));
+            let mut pdu =
+                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            pdu.append_data(login_keys_operational(&ctx.conn.cfg).as_slice());
 
             match ctx.conn.send_request(itt, pdu).await {
                 Err(e) => Transition::Done(Err(e)),

--- a/src/state_machine/login/login_plain.rs
+++ b/src/state_machine/login/login_plain.rs
@@ -4,7 +4,7 @@ use crate::{
     cfg::config::ToLoginKeys,
     models::{
         common::Builder,
-        data_fromat::PDUWithData,
+        data_fromat::PduRequest,
         login::{
             common::Stage,
             request::{LoginRequest, LoginRequestBuilder},
@@ -46,8 +46,7 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for PlainStart {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu =
-                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            let mut pdu = PduRequest::<LoginRequest>::new_request(ctx.buf, &ctx.conn.cfg);
             for key in ctx.conn.cfg.to_login_keys() {
                 pdu.append_data(key.into_bytes().as_slice());
             }

--- a/src/state_machine/login/login_plain.rs
+++ b/src/state_machine/login/login_plain.rs
@@ -46,9 +46,10 @@ impl<'ctx> StateMachine<LoginCtx<'ctx>, LoginStepOut> for PlainStart {
                 return Transition::Done(Err(e));
             }
 
-            let mut pdu = PDUWithData::<LoginRequest>::from_header_slice(ctx.buf);
+            let mut pdu =
+                PDUWithData::<LoginRequest>::from_header_slice(ctx.buf, &ctx.conn.cfg);
             for key in ctx.conn.cfg.to_login_keys() {
-                pdu.append_data(key.into_bytes());
+                pdu.append_data(key.into_bytes().as_slice());
             }
 
             match ctx.conn.send_request(ctx.itt, pdu).await {

--- a/src/state_machine/logout_states.rs
+++ b/src/state_machine/logout_states.rs
@@ -77,7 +77,7 @@ impl<'a> LogoutCtx<'a> {
         header.header.to_bhs_bytes(self.buf.as_mut_slice())?;
 
         let builder: PDUWithData<LogoutRequest> =
-            PDUWithData::from_header_slice(self.buf);
+            PDUWithData::from_header_slice(self.buf, &self.conn.cfg);
         self.conn.send_request(self.itt, builder).await?;
 
         Ok(())

--- a/src/state_machine/nop_states.rs
+++ b/src/state_machine/nop_states.rs
@@ -120,7 +120,7 @@ impl<'a> NopCtx<'a> {
         header.header.to_bhs_bytes(self.buf.as_mut_slice())?;
 
         let builder: PDUWithData<NopOutRequest> =
-            PDUWithData::from_header_slice(self.buf);
+            PDUWithData::from_header_slice(self.buf, &self.conn.cfg);
         self.conn.send_request(self.itt, builder).await?;
         Ok(())
     }
@@ -213,7 +213,8 @@ impl<'ctx> StateMachine<NopCtx<'ctx>, NopStepOut> for Reply {
             if let Err(e) = hdr.to_bhs_bytes(ctx.buf.as_mut_slice()) {
                 return Transition::Done(Err(e));
             }
-            let pdu: PDUWithData<NopOutRequest> = PDUWithData::from_header_slice(ctx.buf);
+            let pdu: PDUWithData<NopOutRequest> =
+                PDUWithData::from_header_slice(ctx.buf, &ctx.conn.cfg);
 
             // Response — fire-and-forget
             if let Err(e) = ctx.conn.send_request(u32::MAX, pdu).await {

--- a/src/state_machine/nop_states.rs
+++ b/src/state_machine/nop_states.rs
@@ -18,7 +18,7 @@ use crate::{
     client::client::ClientConnection,
     models::{
         common::HEADER_LEN,
-        data_fromat::PDUWithData,
+        data_fromat::{PduRequest, PduResponse},
         nop::{
             request::{NopOutRequest, NopOutRequestBuilder},
             response::NopInResponse,
@@ -39,7 +39,7 @@ pub struct NopCtx<'a> {
     pub ttt: u32,
     pub buf: [u8; HEADER_LEN],
 
-    last_response: Option<PDUWithData<NopInResponse>>,
+    last_response: Option<PduResponse<NopInResponse>>,
     state: Option<NopStates>,
 }
 
@@ -89,7 +89,7 @@ impl<'a> NopCtx<'a> {
         _itt: Arc<AtomicU32>,
         cmd_sn: Arc<AtomicU32>,
         exp_stat_sn: Arc<AtomicU32>,
-        response: PDUWithData<NopInResponse>,
+        response: PduResponse<NopInResponse>,
     ) -> Result<Self> {
         let header = response.header_view()?;
         Ok(Self {
@@ -119,8 +119,7 @@ impl<'a> NopCtx<'a> {
 
         header.header.to_bhs_bytes(self.buf.as_mut_slice())?;
 
-        let builder: PDUWithData<NopOutRequest> =
-            PDUWithData::from_header_slice(self.buf, &self.conn.cfg);
+        let builder = PduRequest::<NopOutRequest>::new_request(self.buf, &self.conn.cfg);
         self.conn.send_request(self.itt, builder).await?;
         Ok(())
     }
@@ -213,8 +212,7 @@ impl<'ctx> StateMachine<NopCtx<'ctx>, NopStepOut> for Reply {
             if let Err(e) = hdr.to_bhs_bytes(ctx.buf.as_mut_slice()) {
                 return Transition::Done(Err(e));
             }
-            let pdu: PDUWithData<NopOutRequest> =
-                PDUWithData::from_header_slice(ctx.buf, &ctx.conn.cfg);
+            let pdu = PduRequest::<NopOutRequest>::new_request(ctx.buf, &ctx.conn.cfg);
 
             // Response — fire-and-forget
             if let Err(e) = ctx.conn.send_request(u32::MAX, pdu).await {
@@ -226,11 +224,11 @@ impl<'ctx> StateMachine<NopCtx<'ctx>, NopStepOut> for Reply {
     }
 }
 
-impl<'s> StateMachineCtx<NopCtx<'s>, PDUWithData<NopInResponse>> for NopCtx<'s> {
+impl<'s> StateMachineCtx<NopCtx<'s>, PduResponse<NopInResponse>> for NopCtx<'s> {
     async fn execute(
         &mut self,
         _cancel: &CancellationToken,
-    ) -> Result<PDUWithData<NopInResponse>> {
+    ) -> Result<PduResponse<NopInResponse>> {
         debug!("Loop Nop");
         loop {
             let state = self.state.take().context("state must be set NopCtx")?;

--- a/src/state_machine/read_states.rs
+++ b/src/state_machine/read_states.rs
@@ -27,7 +27,7 @@ use crate::{
         },
         common::{BasicHeaderSegment, HEADER_LEN},
         data::{response::ScsiDataIn, sense_data::SenseData},
-        data_fromat::PDUWithData,
+        data_fromat::{PduRequest, PduResponse},
         opcode::{BhsOpcode, Opcode},
         parse::Pdu,
     },
@@ -36,8 +36,8 @@ use crate::{
 
 #[derive(Debug)]
 pub enum ReadPdu {
-    DataIn(PDUWithData<ScsiDataIn>),
-    CmdResp(PDUWithData<ScsiCommandResponse>),
+    DataIn(PduResponse<ScsiDataIn>),
+    CmdResp(PduResponse<ScsiCommandResponse>),
 }
 
 #[derive(Debug)]
@@ -61,7 +61,7 @@ pub struct ReadCtx<'a> {
     pub cdb: [u8; 16],
     pub buf: [u8; HEADER_LEN],
 
-    pub last_response: Option<PDUWithData<ScsiCommandResponse>>,
+    pub last_response: Option<PduResponse<ScsiCommandResponse>>,
     pub rt: ReadRuntime,
     state: Option<ReadStates>,
 }
@@ -98,7 +98,7 @@ impl<'a> ReadCtx<'a> {
     }
 
     pub async fn recv_any(&self, itt: u32) -> anyhow::Result<ReadPdu> {
-        let (p_any, data): (PDUWithData<Pdu>, Bytes) =
+        let (p_any, data): (PduResponse<Pdu>, Bytes) =
             self.conn.read_response_raw(itt).await?;
         let op = BhsOpcode::try_from(p_any.header_buf[0])?.opcode;
 
@@ -149,19 +149,19 @@ impl<'a> ReadCtx<'a> {
             .task_attribute(TaskAttribute::Simple);
 
         header.header.to_bhs_bytes(self.buf.as_mut_slice())?;
-        let builder: PDUWithData<ScsiCommandRequest> =
-            PDUWithData::from_header_slice(self.buf, &self.conn.cfg);
+        let builder =
+            PduRequest::<ScsiCommandRequest>::new_request(self.buf, &self.conn.cfg);
         self.conn.send_request(self.itt, builder).await?;
 
         self.rt.cur_cmd_sn = Some(sn);
         Ok(esn)
     }
 
-    pub async fn recv_datain(&self, itt: u32) -> Result<PDUWithData<ScsiDataIn>> {
+    pub async fn recv_datain(&self, itt: u32) -> Result<PduResponse<ScsiDataIn>> {
         self.conn.read_response(itt).await
     }
 
-    pub fn apply_datain_append(&mut self, pdu: &PDUWithData<ScsiDataIn>) -> Result<bool> {
+    pub fn apply_datain_append(&mut self, pdu: &PduResponse<ScsiDataIn>) -> Result<bool> {
         let h = pdu.header_view()?;
 
         let off = h.buffer_offset.get() as usize;
@@ -203,7 +203,7 @@ impl<'a> ReadCtx<'a> {
             ));
         }
 
-        let rsp: PDUWithData<ScsiCommandResponse> = match self.last_response.take() {
+        let rsp: PduResponse<ScsiCommandResponse> = match self.last_response.take() {
             Some(r) => r,
             None => self.conn.read_response(itt).await?,
         };
@@ -340,7 +340,8 @@ impl<'ctx> StateMachine<ReadCtx<'ctx>, ReadStepOut> for Finish {
 
             if got != expected_after_residual {
                 return Transition::Done(Err(anyhow!(
-                    "read length mismatch: requested={}, residual={}, expected_after_residual={}, got={}",
+                    "read length mismatch: requested={}, residual={}, \
+                     expected_after_residual={}, got={}",
                     requested,
                     residual,
                     expected_after_residual,
@@ -359,7 +360,7 @@ pub struct ReadOutcome {
     pub data: Vec<u8>,
     /// Final SCSI Command Response (if target sent one).
     /// When status was carried by the last Data-In (S-bit set), this is None.
-    pub last_response: Option<PDUWithData<ScsiCommandResponse>>,
+    pub last_response: Option<PduResponse<ScsiCommandResponse>>,
 }
 
 impl<'ctx> StateMachineCtx<ReadCtx<'ctx>, ReadOutcome> for ReadCtx<'ctx> {

--- a/src/state_machine/write_states.rs
+++ b/src/state_machine/write_states.rs
@@ -165,7 +165,6 @@ impl<'a> WriteCtx<'a> {
 
             let header = pdu.header_view_mut()?;
 
-            header.set_data_length_bytes(take as u32);
             if last_chunk_in_window {
                 header.set_final_bit();
             } else {

--- a/src/state_machine/write_states.rs
+++ b/src/state_machine/write_states.rs
@@ -28,7 +28,7 @@ use crate::{
             request::{ScsiDataOut, ScsiDataOutBuilder},
             sense_data::SenseData,
         },
-        data_fromat::PDUWithData,
+        data_fromat::{PduRequest, PduResponse},
         ready_2_transfer::response::ReadyToTransfer,
     },
     state_machine::common::{StateMachine, StateMachineCtx, Transition},
@@ -51,7 +51,7 @@ pub struct WriteCtx<'a> {
     pub sent_bytes: usize,
     pub total_bytes: usize,
 
-    pub last_response: Option<PDUWithData<ScsiCommandResponse>>,
+    pub last_response: Option<PduResponse<ScsiCommandResponse>>,
     state: Option<WriteStates>,
 }
 
@@ -101,15 +101,14 @@ impl<'a> WriteCtx<'a> {
             .task_attribute(TaskAttribute::Simple);
 
         header.header.to_bhs_bytes(&mut self.buf)?;
-        let pdu: PDUWithData<ScsiCommandRequest> =
-            PDUWithData::from_header_slice(self.buf, &self.conn.cfg);
+        let pdu = PduRequest::<ScsiCommandRequest>::new_request(self.buf, &self.conn.cfg);
         self.conn.send_request(self.itt, pdu).await?;
 
         Ok(())
     }
 
-    async fn recv_r2t(&self, itt: u32) -> Result<PDUWithData<ReadyToTransfer>> {
-        let r2t: PDUWithData<ReadyToTransfer> = self.conn.read_response(itt).await?;
+    async fn recv_r2t(&self, itt: u32) -> Result<PduResponse<ReadyToTransfer>> {
+        let r2t: PduResponse<ReadyToTransfer> = self.conn.read_response(itt).await?;
         let header = r2t.header_view()?;
         self.exp_stat_sn
             .store(header.stat_sn.get().wrapping_add(1), Ordering::SeqCst);
@@ -161,8 +160,8 @@ impl<'a> WriteCtx<'a> {
 
             header.header.to_bhs_bytes(self.buf.as_mut_slice())?;
 
-            let mut pdu: PDUWithData<ScsiDataOut> =
-                PDUWithData::from_header_slice(self.buf, &self.conn.cfg);
+            let mut pdu =
+                PduRequest::<ScsiDataOut>::new_request(self.buf, &self.conn.cfg);
 
             let header = pdu.header_view_mut()?;
 
@@ -186,7 +185,7 @@ impl<'a> WriteCtx<'a> {
 
     /// Wait for the SCSI Response and validate success.
     async fn wait_scsi_response(&mut self, itt: u32) -> Result<()> {
-        let rsp: PDUWithData<ScsiCommandResponse> = self.conn.read_response(itt).await?;
+        let rsp: PduResponse<ScsiCommandResponse> = self.conn.read_response(itt).await?;
         let header = rsp.header_view()?;
         self.exp_stat_sn
             .store(header.stat_sn.get().wrapping_add(1), Ordering::SeqCst);
@@ -245,8 +244,8 @@ impl<'a> WriteCtx<'a> {
             .task_attribute(TaskAttribute::Simple);
 
         header.header.to_bhs_bytes(&mut self.buf)?;
-        let mut pdu: PDUWithData<ScsiCommandRequest> =
-            PDUWithData::from_header_slice(self.buf, &self.conn.cfg);
+        let mut pdu =
+            PduRequest::<ScsiCommandRequest>::new_request(self.buf, &self.conn.cfg);
 
         if imm_len > 0 {
             pdu.append_data(&self.payload[0..imm_len]);
@@ -291,8 +290,8 @@ impl<'a> WriteCtx<'a> {
 
             header.header.to_bhs_bytes(self.buf.as_mut_slice())?;
 
-            let mut pdu: PDUWithData<ScsiDataOut> =
-                PDUWithData::from_header_slice(self.buf, &self.conn.cfg);
+            let mut pdu =
+                PduRequest::<ScsiDataOut>::new_request(self.buf, &self.conn.cfg);
             {
                 let h = pdu.header_view_mut()?;
                 h.set_data_length_bytes(take as u32);
@@ -469,7 +468,7 @@ impl<'ctx> StateMachine<WriteCtx<'ctx>, WriteStep> for Finish {
 #[derive(Debug)]
 pub struct WriteOutcome {
     /// Final SCSI Command Response (always present for WRITE).
-    pub last_response: PDUWithData<ScsiCommandResponse>,
+    pub last_response: PduResponse<ScsiCommandResponse>,
     /// Bytes actually sent (sum over all Data-Out PDUs).
     pub sent_bytes: usize,
     /// Total intended bytes (payload length).

--- a/tests/_unit_entry.rs
+++ b/tests/_unit_entry.rs
@@ -4,6 +4,37 @@
 #![allow(clippy::all)]
 
 mod unit_tests {
+    use std::fs;
+
+    use anyhow::Result;
+    use hex::FromHex;
+    use iscsi_client_rs::{
+        cfg::config::Config,
+        client::pdu_connection::FromBytes,
+        models::{
+            common::{BasicHeaderSegment, HEADER_LEN},
+            data_fromat::{PDUWithData, ZeroCopyType},
+        },
+    };
+
+    // Helper to load a hex fixture and decode it to a byte vector.
+    fn load_fixture(path: &str) -> Result<Vec<u8>> {
+        let s = fs::read_to_string(path)?;
+        let cleaned = s.trim().replace(|c: char| c.is_whitespace(), "");
+        Ok(Vec::from_hex(&cleaned)?)
+    }
+
+    fn parse<T: BasicHeaderSegment + FromBytes + ZeroCopyType>(
+        bytes: &[u8],
+        cfg: &Config,
+    ) -> Result<PDUWithData<T>> {
+        let mut header_buf = [0u8; HEADER_LEN];
+        header_buf.copy_from_slice(&bytes[..HEADER_LEN]);
+        let mut pdu = PDUWithData::<T>::from_header_slice(header_buf, &cfg);
+        pdu.parse_with_buff(&bytes[HEADER_LEN..], false, false)?;
+        Ok(pdu)
+    }
+
     pub mod test_login;
     pub mod test_nop;
     pub mod test_read;

--- a/tests/config_logger.yaml
+++ b/tests/config_logger.yaml
@@ -1,5 +1,5 @@
 logger:
-  level: "debug" # Уровень логирования: trace, debug, info, warn, error
+  level: "info" # Уровень логирования: trace, debug, info, warn, error
   output: "stdout" # Куда выводить логи: stdout, stderr, file
   is_show_line: false # Показывать ли номер строки в логах: true, false
   is_show_module_path: false # Показывать ли путь до файла: true, false

--- a/tests/unit_tests/test_login.rs
+++ b/tests/unit_tests/test_login.rs
@@ -15,7 +15,7 @@ use iscsi_client_rs::{
     },
     models::{
         common::{Builder, HEADER_LEN},
-        data_fromat::PDUWithData,
+        data_fromat::{PduRequest, PduResponse},
         login::{
             common::Stage,
             request::{LoginRequest, LoginRequestBuilder},
@@ -24,7 +24,7 @@ use iscsi_client_rs::{
     },
 };
 
-use crate::unit_tests::{load_fixture, parse};
+use crate::unit_tests::{load_fixture, parse_imm, parse_mut};
 
 const ISID: [u8; 6] = [0, 2, 61, 0, 0, 14];
 
@@ -88,7 +88,7 @@ fn test_login_request() -> Result<()> {
 
     let bytes = load_fixture("tests/unit_tests/fixtures/login/login_request.hex")?;
 
-    let parsed: PDUWithData<LoginRequest> = parse(&bytes, &cfg)?;
+    let parsed: PduRequest<LoginRequest> = parse_mut(&bytes, &cfg)?;
     assert!(!parsed.data()?.is_empty());
     assert!(parsed.header_digest.is_none());
     assert!(parsed.data_digest.is_none());
@@ -105,7 +105,7 @@ fn test_login_request() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     header_builder.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut builder = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    let mut builder = PduRequest::<LoginRequest>::new_request(header_buf, &cfg);
 
     for key in cfg.to_login_keys() {
         builder.append_data(key.into_bytes().as_slice());
@@ -136,7 +136,7 @@ fn test_login_response_echo() -> Result<()> {
         .context("failed to resolve or load config")?;
 
     let resp_bytes = load_fixture("tests/unit_tests/fixtures/login/login_response.hex")?;
-    let parsed: PDUWithData<LoginResponse> = parse(&resp_bytes, &cfg)?;
+    let parsed: PduResponse<LoginResponse> = parse_imm(&resp_bytes, &cfg)?;
 
     assert!(!parsed.data()?.is_empty());
     assert!(parsed.header_digest.is_none());
@@ -174,7 +174,7 @@ fn chap_step1_security_only() -> Result<()> {
 
     let req_exp = load_fixture("tests/unit_tests/fixtures/login/step1_req.hex")?;
     let resp_bytes = load_fixture("tests/unit_tests/fixtures/login/step1_resp.hex")?;
-    let _r1: PDUWithData<LoginResponse> = parse(&resp_bytes, &cfg)?;
+    let _r1: PduResponse<LoginResponse> = parse_imm(&resp_bytes, &cfg)?;
 
     let s1_hdr = LoginRequestBuilder::new(ISID, 0)
         .transit()
@@ -188,7 +188,7 @@ fn chap_step1_security_only() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     s1_hdr.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut s1 = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    let mut s1 = PduRequest::<LoginRequest>::new_request(header_buf, &cfg);
     s1.append_data(login_keys_security(&cfg).as_slice());
 
     let (hdr_bytes, data_bytes) = &s1.build(
@@ -199,8 +199,8 @@ fn chap_step1_security_only() -> Result<()> {
     let mut got = hdr_bytes.to_vec();
     got.extend_from_slice(data_bytes);
 
-    let exp_pdu: PDUWithData<LoginRequest> = parse(&req_exp, &cfg)?;
-    let got_pdu: PDUWithData<LoginRequest> = parse(&got, &cfg)?;
+    let exp_pdu: PduRequest<LoginRequest> = parse_mut(&req_exp, &cfg)?;
+    let got_pdu: PduRequest<LoginRequest> = parse_mut(&got, &cfg)?;
     assert_eq!(got_pdu.header_buf, exp_pdu.header_buf, "step1 BHS differs");
     assert_eq!(
         split_zeroes(&got_pdu.data()?),
@@ -216,11 +216,11 @@ fn chap_step2_chap_a() -> Result<()> {
         .and_then(Config::load_from_file)
         .context("failed to load tests/unit_tests/config_chap.yaml")?;
 
-    let r1: PDUWithData<LoginResponse> = parse(
+    let r1: PduResponse<LoginResponse> = parse_imm(
         &load_fixture("tests/unit_tests/fixtures/login/step1_resp.hex")?,
         &cfg,
     )?;
-    let req_exp: PDUWithData<LoginRequest> = parse(
+    let req_exp: PduRequest<LoginRequest> = parse_mut(
         &load_fixture("tests/unit_tests/fixtures/login/step2_req.hex")?,
         &cfg,
     )?;
@@ -238,7 +238,7 @@ fn chap_step2_chap_a() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     s2_hdr.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut s2 = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    let mut s2 = PduRequest::<LoginRequest>::new_request(header_buf, &cfg);
     s2.append_data(b"CHAP_A=5\x00".as_slice());
 
     assert_eq!(s2.header_buf, req_exp.header_buf, "step2 BHS differs");
@@ -256,7 +256,7 @@ fn chap_step3_chap_response() -> Result<()> {
         .and_then(Config::load_from_file)
         .context("failed to load tests/config_chap.yaml")?;
 
-    let r2: PDUWithData<LoginResponse> = parse(
+    let r2: PduResponse<LoginResponse> = parse_imm(
         &load_fixture("tests/unit_tests/fixtures/login/step2_resp.hex")?,
         &cfg,
     )?;
@@ -283,7 +283,7 @@ fn chap_step3_chap_response() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     s3_hdr.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut s3 = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    let mut s3 = PduRequest::<LoginRequest>::new_request(header_buf, &cfg);
     s3.append_data(login_keys_chap_response(user, &chap_r).as_slice());
 
     let (hdr_bytes, data_bytes) = &s3.build(
@@ -294,8 +294,8 @@ fn chap_step3_chap_response() -> Result<()> {
     let mut got = hdr_bytes.to_vec();
     got.extend_from_slice(data_bytes);
 
-    let exp_pdu: PDUWithData<LoginRequest> = parse(&req_exp, &cfg)?;
-    let got_pdu: PDUWithData<LoginRequest> = parse(&got, &cfg)?;
+    let exp_pdu: PduRequest<LoginRequest> = parse_mut(&req_exp, &cfg)?;
+    let got_pdu: PduRequest<LoginRequest> = parse_mut(&got, &cfg)?;
     assert_eq!(got_pdu.header_buf, exp_pdu.header_buf, "step3 BHS differs");
     assert_eq!(
         split_zeroes(&got_pdu.data()?),
@@ -311,7 +311,7 @@ fn chap_step4_oper_to_ff_with_ops() -> Result<()> {
         .and_then(Config::load_from_file)
         .context("failed to load tests/config_chap.yaml")?;
 
-    let r2: PDUWithData<LoginResponse> = parse(
+    let r2: PduResponse<LoginResponse> = parse_imm(
         &load_fixture("tests/unit_tests/fixtures/login/step3_resp.hex")?,
         &cfg,
     )?;
@@ -331,7 +331,7 @@ fn chap_step4_oper_to_ff_with_ops() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     s4_hdr.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut s4 = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    let mut s4 = PduRequest::<LoginRequest>::new_request(header_buf, &cfg);
     s4.append_data(login_keys_operational(&cfg).as_slice());
 
     let (hdr_bytes, data_bytes) = &s4.build(
@@ -342,8 +342,8 @@ fn chap_step4_oper_to_ff_with_ops() -> Result<()> {
     let mut got = hdr_bytes.to_vec();
     got.extend_from_slice(data_bytes);
 
-    let exp_pdu: PDUWithData<LoginRequest> = parse(&req_exp, &cfg)?;
-    let got_pdu: PDUWithData<LoginRequest> = parse(&got, &cfg)?;
+    let exp_pdu: PduRequest<LoginRequest> = parse_mut(&req_exp, &cfg)?;
+    let got_pdu: PduRequest<LoginRequest> = parse_mut(&got, &cfg)?;
     assert_eq!(got_pdu.header_buf, exp_pdu.header_buf, "step4 BHS differs");
     assert_eq!(
         split_zeroes(&got_pdu.data()?),

--- a/tests/unit_tests/test_login.rs
+++ b/tests/unit_tests/test_login.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2012-2025 Andrei Maltsev
 
-use std::{collections::BTreeSet, fs};
+use std::collections::BTreeSet;
 
 use anyhow::{Context, Result, bail};
-use hex::FromHex;
 use iscsi_client_rs::{
     cfg::{
         cli::resolve_config_path,
@@ -24,6 +23,8 @@ use iscsi_client_rs::{
         },
     },
 };
+
+use crate::unit_tests::{load_fixture, parse};
 
 const ISID: [u8; 6] = [0, 2, 61, 0, 0, 14];
 
@@ -72,31 +73,6 @@ fn calc_chap_r_hex(id: u8, secret: &[u8], challenge: &[u8]) -> String {
     s
 }
 
-fn load_fixture(path: &str) -> Result<Vec<u8>> {
-    let s = fs::read_to_string(path)?;
-    let cleaned = s.trim().replace(|c: char| c.is_whitespace(), "");
-    Ok(Vec::from_hex(&cleaned)?)
-}
-
-fn parse_resp(bytes: &[u8]) -> Result<PDUWithData<LoginResponse>> {
-    let mut header_buf = [0u8; HEADER_LEN];
-    header_buf.copy_from_slice(&bytes[..HEADER_LEN]);
-
-    let mut pdu = PDUWithData::<LoginResponse>::from_header_slice(header_buf);
-
-    pdu.parse_with_buff(&bytes[HEADER_LEN..], false, false)?;
-    Ok(pdu)
-}
-
-fn parse_req(bytes: &[u8]) -> Result<PDUWithData<LoginRequest>> {
-    let mut header_buf = [0u8; HEADER_LEN];
-    header_buf.copy_from_slice(&bytes[..HEADER_LEN]);
-
-    let mut pdu = PDUWithData::<LoginRequest>::from_header_slice(header_buf);
-    pdu.parse_with_buff(&bytes[HEADER_LEN..], false, false)?;
-    Ok(pdu)
-}
-
 fn split_zeroes(buf: &[u8]) -> BTreeSet<String> {
     buf.split(|&b| b == 0)
         .filter(|s| !s.is_empty())
@@ -112,8 +88,8 @@ fn test_login_request() -> Result<()> {
 
     let bytes = load_fixture("tests/unit_tests/fixtures/login/login_request.hex")?;
 
-    let parsed = parse_req(&bytes)?;
-    assert!(!parsed.data.is_empty());
+    let parsed: PDUWithData<LoginRequest> = parse(&bytes, &cfg)?;
+    assert!(!parsed.data()?.is_empty());
     assert!(parsed.header_digest.is_none());
     assert!(parsed.data_digest.is_none());
 
@@ -129,10 +105,10 @@ fn test_login_request() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     header_builder.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut builder = PDUWithData::<LoginRequest>::from_header_slice(header_buf);
+    let mut builder = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
 
     for key in cfg.to_login_keys() {
-        builder.append_data(key.into_bytes());
+        builder.append_data(key.into_bytes().as_slice());
     }
 
     assert_eq!(
@@ -147,7 +123,7 @@ fn test_login_request() -> Result<()> {
     )?;
 
     let left: BTreeSet<_> = split_zeroes(body);
-    let right: BTreeSet<_> = split_zeroes(&parsed.data);
+    let right: BTreeSet<_> = split_zeroes(&parsed.data()?);
     assert_eq!(left, right, "data segment key set differs");
 
     Ok(())
@@ -160,9 +136,9 @@ fn test_login_response_echo() -> Result<()> {
         .context("failed to resolve or load config")?;
 
     let resp_bytes = load_fixture("tests/unit_tests/fixtures/login/login_response.hex")?;
-    let parsed = parse_resp(&resp_bytes)?;
+    let parsed: PDUWithData<LoginResponse> = parse(&resp_bytes, &cfg)?;
 
-    assert!(!parsed.data.is_empty());
+    assert!(!parsed.data()?.is_empty());
     assert!(parsed.header_digest.is_none());
     assert!(parsed.data_digest.is_none());
 
@@ -198,7 +174,7 @@ fn chap_step1_security_only() -> Result<()> {
 
     let req_exp = load_fixture("tests/unit_tests/fixtures/login/step1_req.hex")?;
     let resp_bytes = load_fixture("tests/unit_tests/fixtures/login/step1_resp.hex")?;
-    let _r1 = parse_resp(&resp_bytes)?;
+    let _r1: PDUWithData<LoginResponse> = parse(&resp_bytes, &cfg)?;
 
     let s1_hdr = LoginRequestBuilder::new(ISID, 0)
         .transit()
@@ -212,8 +188,8 @@ fn chap_step1_security_only() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     s1_hdr.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut s1 = PDUWithData::<LoginRequest>::from_header_slice(header_buf);
-    s1.append_data(login_keys_security(&cfg));
+    let mut s1 = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    s1.append_data(login_keys_security(&cfg).as_slice());
 
     let (hdr_bytes, data_bytes) = &s1.build(
         cfg.login.negotiation.max_recv_data_segment_length as usize,
@@ -223,12 +199,12 @@ fn chap_step1_security_only() -> Result<()> {
     let mut got = hdr_bytes.to_vec();
     got.extend_from_slice(data_bytes);
 
-    let exp_pdu = parse_req(&req_exp)?;
-    let got_pdu = parse_req(&got)?;
+    let exp_pdu: PDUWithData<LoginRequest> = parse(&req_exp, &cfg)?;
+    let got_pdu: PDUWithData<LoginRequest> = parse(&got, &cfg)?;
     assert_eq!(got_pdu.header_buf, exp_pdu.header_buf, "step1 BHS differs");
     assert_eq!(
-        split_zeroes(&got_pdu.data),
-        split_zeroes(&exp_pdu.data),
+        split_zeroes(&got_pdu.data()?),
+        split_zeroes(&exp_pdu.data()?),
         "step1 TLV set differs"
     );
     Ok(())
@@ -236,16 +212,18 @@ fn chap_step1_security_only() -> Result<()> {
 
 #[test]
 fn chap_step2_chap_a() -> Result<()> {
-    let _cfg = resolve_config_path("tests/config_chap.yaml")
+    let cfg = resolve_config_path("tests/config_chap.yaml")
         .and_then(Config::load_from_file)
         .context("failed to load tests/unit_tests/config_chap.yaml")?;
 
-    let r1 = parse_resp(&load_fixture(
-        "tests/unit_tests/fixtures/login/step1_resp.hex",
-    )?)?;
-    let req_exp = parse_req(&load_fixture(
-        "tests/unit_tests/fixtures/login/step2_req.hex",
-    )?)?;
+    let r1: PDUWithData<LoginResponse> = parse(
+        &load_fixture("tests/unit_tests/fixtures/login/step1_resp.hex")?,
+        &cfg,
+    )?;
+    let req_exp: PDUWithData<LoginRequest> = parse(
+        &load_fixture("tests/unit_tests/fixtures/login/step2_req.hex")?,
+        &cfg,
+    )?;
 
     let r1_header = r1.header_view()?;
 
@@ -260,12 +238,13 @@ fn chap_step2_chap_a() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     s2_hdr.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut s2 = PDUWithData::<LoginRequest>::from_header_slice(header_buf);
-    s2.append_data(b"CHAP_A=5\x00".to_vec());
+    let mut s2 = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    s2.append_data(b"CHAP_A=5\x00".as_slice());
 
     assert_eq!(s2.header_buf, req_exp.header_buf, "step2 BHS differs");
     assert_eq!(
-        s2.data, req_exp.data,
+        s2.data()?,
+        req_exp.data()?,
         "step2 request bytes differ from fixture"
     );
     Ok(())
@@ -277,10 +256,11 @@ fn chap_step3_chap_response() -> Result<()> {
         .and_then(Config::load_from_file)
         .context("failed to load tests/config_chap.yaml")?;
 
-    let r2 = parse_resp(&load_fixture(
-        "tests/unit_tests/fixtures/login/step2_resp.hex",
-    )?)?;
-    let (chap_i, chap_c) = parse_chap_challenge_tlv(&r2.data)?;
+    let r2: PDUWithData<LoginResponse> = parse(
+        &load_fixture("tests/unit_tests/fixtures/login/step2_resp.hex")?,
+        &cfg,
+    )?;
+    let (chap_i, chap_c) = parse_chap_challenge_tlv(&r2.data()?)?;
     let (user, secret) = match &cfg.login.auth {
         AuthConfig::Chap(c) => (c.username.as_str(), c.secret.as_bytes()),
         _ => bail!("tests/config_chap.yaml must provide CHAP credentials"),
@@ -303,8 +283,8 @@ fn chap_step3_chap_response() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     s3_hdr.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut s3 = PDUWithData::<LoginRequest>::from_header_slice(header_buf);
-    s3.append_data(login_keys_chap_response(user, &chap_r));
+    let mut s3 = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    s3.append_data(login_keys_chap_response(user, &chap_r).as_slice());
 
     let (hdr_bytes, data_bytes) = &s3.build(
         cfg.login.negotiation.max_recv_data_segment_length as usize,
@@ -314,12 +294,12 @@ fn chap_step3_chap_response() -> Result<()> {
     let mut got = hdr_bytes.to_vec();
     got.extend_from_slice(data_bytes);
 
-    let exp_pdu = parse_req(&req_exp)?;
-    let got_pdu = parse_req(&got)?;
+    let exp_pdu: PDUWithData<LoginRequest> = parse(&req_exp, &cfg)?;
+    let got_pdu: PDUWithData<LoginRequest> = parse(&got, &cfg)?;
     assert_eq!(got_pdu.header_buf, exp_pdu.header_buf, "step3 BHS differs");
     assert_eq!(
-        split_zeroes(&got_pdu.data),
-        split_zeroes(&exp_pdu.data),
+        split_zeroes(&got_pdu.data()?),
+        split_zeroes(&exp_pdu.data()?),
         "step3 TLV set differs"
     );
     Ok(())
@@ -331,9 +311,10 @@ fn chap_step4_oper_to_ff_with_ops() -> Result<()> {
         .and_then(Config::load_from_file)
         .context("failed to load tests/config_chap.yaml")?;
 
-    let r2 = parse_resp(&load_fixture(
-        "tests/unit_tests/fixtures/login/step3_resp.hex",
-    )?)?;
+    let r2: PDUWithData<LoginResponse> = parse(
+        &load_fixture("tests/unit_tests/fixtures/login/step3_resp.hex")?,
+        &cfg,
+    )?;
     let req_exp = load_fixture("tests/unit_tests/fixtures/login/step4_req.hex")?;
 
     let r2_header = r2.header_view()?;
@@ -350,8 +331,8 @@ fn chap_step4_oper_to_ff_with_ops() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     s4_hdr.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut s4 = PDUWithData::<LoginRequest>::from_header_slice(header_buf);
-    s4.append_data(login_keys_operational(&cfg));
+    let mut s4 = PDUWithData::<LoginRequest>::from_header_slice(header_buf, &cfg);
+    s4.append_data(login_keys_operational(&cfg).as_slice());
 
     let (hdr_bytes, data_bytes) = &s4.build(
         cfg.login.negotiation.max_recv_data_segment_length as usize,
@@ -361,12 +342,12 @@ fn chap_step4_oper_to_ff_with_ops() -> Result<()> {
     let mut got = hdr_bytes.to_vec();
     got.extend_from_slice(data_bytes);
 
-    let exp_pdu = parse_req(&req_exp)?;
-    let got_pdu = parse_req(&got)?;
+    let exp_pdu: PDUWithData<LoginRequest> = parse(&req_exp, &cfg)?;
+    let got_pdu: PDUWithData<LoginRequest> = parse(&got, &cfg)?;
     assert_eq!(got_pdu.header_buf, exp_pdu.header_buf, "step4 BHS differs");
     assert_eq!(
-        split_zeroes(&got_pdu.data),
-        split_zeroes(&exp_pdu.data),
+        split_zeroes(&got_pdu.data()?),
+        split_zeroes(&exp_pdu.data()?),
         "step4 TLV set differs"
     );
     Ok(())

--- a/tests/unit_tests/test_read_capacity.rs
+++ b/tests/unit_tests/test_read_capacity.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2012-2025 Andrei Maltsev
 
-use std::fs;
 
 use anyhow::{Context, Result};
-use hex::FromHex;
 use iscsi_client_rs::{
     cfg::{cli::resolve_config_path, config::Config, enums::Digest},
     control_block::read_capacity::{
@@ -22,12 +20,7 @@ use iscsi_client_rs::{
     },
 };
 
-// Helper to load a hex fixture and decode it to a byte vector.
-fn load_fixture(path: &str) -> Result<Vec<u8>> {
-    let s = fs::read_to_string(path)?;
-    let cleaned = s.trim().replace(|c: char| c.is_whitespace(), "");
-    Ok(Vec::from_hex(&cleaned)?)
-}
+use crate::unit_tests::load_fixture;
 
 #[test]
 fn test_read_capacity10_request_build() -> Result<()> {
@@ -62,7 +55,7 @@ fn test_read_capacity10_request_build() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     header_builder.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut pdu = PDUWithData::<ScsiCommandRequest>::from_header_slice(header_buf);
+    let mut pdu = PDUWithData::<ScsiCommandRequest>::from_header_slice(header_buf, &cfg);
 
     let (hdr_bytes, body_bytes) = pdu.build(
         cfg.login.negotiation.max_recv_data_segment_length as usize,
@@ -113,7 +106,7 @@ fn test_read_capacity16_request_build() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     header_builder.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut pdu = PDUWithData::<ScsiCommandRequest>::from_header_slice(header_buf);
+    let mut pdu = PDUWithData::<ScsiCommandRequest>::from_header_slice(header_buf, &cfg);
 
     let (hdr_bytes, body_bytes) = pdu.build(
         cfg.login.negotiation.max_recv_data_segment_length as usize,
@@ -134,6 +127,10 @@ fn test_read_capacity16_request_build() -> Result<()> {
 /// READ CAPACITY(10) — response
 #[test]
 fn test_rc10_response_parse() -> Result<()> {
+    let cfg = resolve_config_path("tests/config.yaml")
+        .and_then(Config::load_from_file)
+        .context("failed to resolve or load config")?;
+
     let raw = load_fixture(
         "tests/unit_tests/fixtures/scsi_commands/read_capacity10_response.hex",
     )
@@ -151,7 +148,7 @@ fn test_rc10_response_parse() -> Result<()> {
     let mut hdr_buf = [0u8; HEADER_LEN];
     hdr_buf.copy_from_slice(hdr_bytes);
 
-    let mut pdu = PDUWithData::<ScsiDataIn>::from_header_slice(hdr_buf);
+    let mut pdu = PDUWithData::<ScsiDataIn>::from_header_slice(hdr_buf, &cfg);
     pdu.parse_with_buff(body_bytes, false, false)
         .context("failed to parse ScsiDataIn PDU body")?;
 
@@ -168,17 +165,17 @@ fn test_rc10_response_parse() -> Result<()> {
 
     // Length checks
     assert_eq!(
-        pdu.data.len(),
+        pdu.data()?.len(),
         header.get_data_length_bytes(),
         "payload length != DataSegmentLength"
     );
     assert!(
-        pdu.data.len() >= 8,
+        pdu.data()?.len() >= 8,
         "RC(10) payload must be at least 8 bytes"
     );
 
     // Parse RC(10) payload
-    let rc10: &Rc10Raw = parse_read_capacity10_zerocopy(&pdu.data)
+    let rc10: &Rc10Raw = parse_read_capacity10_zerocopy(&pdu.data()?)
         .context("failed to zerocopy-parse RC(10) body")?;
 
     let blk = rc10.block_len.get();
@@ -195,6 +192,10 @@ fn test_rc10_response_parse() -> Result<()> {
 /// READ CAPACITY(16) — response
 #[test]
 fn test_rc16_response_parse() -> Result<()> {
+    let cfg = resolve_config_path("tests/config.yaml")
+        .and_then(Config::load_from_file)
+        .context("failed to resolve or load config")?;
+
     let raw = load_fixture(
         "tests/unit_tests/fixtures/scsi_commands/read_capacity16_response.hex",
     )
@@ -212,7 +213,7 @@ fn test_rc16_response_parse() -> Result<()> {
     let mut hdr_buf = [0u8; HEADER_LEN];
     hdr_buf.copy_from_slice(hdr_bytes);
 
-    let mut pdu = PDUWithData::<ScsiDataIn>::from_header_slice(hdr_buf);
+    let mut pdu = PDUWithData::<ScsiDataIn>::from_header_slice(hdr_buf, &cfg);
     pdu.parse_with_buff(body_bytes, false, false)
         .context("failed to parse ScsiDataIn PDU body")?;
 
@@ -227,16 +228,16 @@ fn test_rc16_response_parse() -> Result<()> {
     );
 
     assert_eq!(
-        pdu.data.len(),
+        pdu.data()?.len(),
         header.get_data_length_bytes(),
         "payload length != DataSegmentLength"
     );
     assert!(
-        pdu.data.len() >= 12,
+        pdu.data()?.len() >= 12,
         "RC(16) payload must be at least 12 bytes (max_lba[8] + blk_len[4])"
     );
 
-    let rc16: &Rc16Raw = parse_read_capacity16_zerocopy(&pdu.data)
+    let rc16: &Rc16Raw = parse_read_capacity16_zerocopy(&pdu.data()?)
         .context("failed to zerocopy-parse RC(16) body head")?;
 
     let blk = rc16.block_len.get();

--- a/tests/unit_tests/test_ready_to_transfer.rs
+++ b/tests/unit_tests/test_ready_to_transfer.rs
@@ -1,38 +1,37 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2012-2025 Andrei Maltsev
 
-use std::fs;
 
-use anyhow::Result;
-use hex::FromHex;
-use iscsi_client_rs::models::{
-    common::HEADER_LEN,
-    data_fromat::PDUWithData,
-    opcode::{BhsOpcode, Opcode},
-    ready_2_transfer::response::ReadyToTransfer,
+use anyhow::{Context, Result};
+use iscsi_client_rs::{
+    cfg::{cli::resolve_config_path, config::Config},
+    models::{
+        common::HEADER_LEN,
+        data_fromat::PDUWithData,
+        opcode::{BhsOpcode, Opcode},
+        ready_2_transfer::response::ReadyToTransfer,
+    },
 };
 
-fn load_fixture(path: &str) -> Result<Vec<u8>> {
-    let s = fs::read_to_string(path)?;
-    let cleaned = s.trim().replace(|c: char| c.is_whitespace(), "");
-    Ok(Vec::from_hex(&cleaned)?)
-}
+use crate::unit_tests::load_fixture;
 
 #[test]
 fn test_reject_parse() -> Result<()> {
+    let cfg = resolve_config_path("tests/config.yaml")
+        .and_then(Config::load_from_file)
+        .context("failed to resolve or load config")?;
+
     let bytes =
         load_fixture("tests/unit_tests/fixtures/scsi_commands/ready_to_transfer.hex")?;
     assert!(bytes.len() >= HEADER_LEN);
 
-    println!("{:?}", &bytes[HEADER_LEN..]);
-
     let mut hdr_buf = [0u8; HEADER_LEN];
     hdr_buf.copy_from_slice(&bytes[..HEADER_LEN]);
 
-    let mut pdu = PDUWithData::<ReadyToTransfer>::from_header_slice(hdr_buf);
+    let mut pdu = PDUWithData::<ReadyToTransfer>::from_header_slice(hdr_buf, &cfg);
     pdu.parse_with_buff(&bytes[HEADER_LEN..], false, false)?;
 
-    assert!(pdu.data.is_empty());
+    assert!(pdu.data()?.is_empty());
     assert!(pdu.header_digest.is_none());
     assert!(pdu.data_digest.is_none());
 

--- a/tests/unit_tests/test_ready_to_transfer.rs
+++ b/tests/unit_tests/test_ready_to_transfer.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2012-2025 Andrei Maltsev
 
-
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use iscsi_client_rs::{
     cfg::{cli::resolve_config_path, config::Config},
     models::{
         common::HEADER_LEN,
-        data_fromat::PDUWithData,
+        data_fromat::PduResponse,
         opcode::{BhsOpcode, Opcode},
         ready_2_transfer::response::ReadyToTransfer,
     },
@@ -28,8 +28,8 @@ fn test_reject_parse() -> Result<()> {
     let mut hdr_buf = [0u8; HEADER_LEN];
     hdr_buf.copy_from_slice(&bytes[..HEADER_LEN]);
 
-    let mut pdu = PDUWithData::<ReadyToTransfer>::from_header_slice(hdr_buf, &cfg);
-    pdu.parse_with_buff(&bytes[HEADER_LEN..], false, false)?;
+    let mut pdu = PduResponse::<ReadyToTransfer>::from_header_slice(hdr_buf, &cfg);
+    pdu.parse_with_buff(&Bytes::copy_from_slice(&bytes[HEADER_LEN..]), false, false)?;
 
     assert!(pdu.data()?.is_empty());
     assert!(pdu.header_digest.is_none());

--- a/tests/unit_tests/test_reject.rs
+++ b/tests/unit_tests/test_reject.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2012-2025 Andrei Maltsev
 
-
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use iscsi_client_rs::{
     cfg::{cli::resolve_config_path, config::Config},
     models::{
@@ -29,7 +29,7 @@ fn test_reject_parse() -> Result<()> {
     hdr_buf.copy_from_slice(&bytes[..HEADER_LEN]);
 
     let mut pdu = PDUWithData::<RejectPdu>::from_header_slice(hdr_buf, &cfg);
-    pdu.parse_with_buff(&bytes[HEADER_LEN..], false, false)?;
+    pdu.parse_with_buff(&Bytes::copy_from_slice(&bytes[HEADER_LEN..]), false, false)?;
 
     assert!(!pdu.data()?.is_empty());
     assert!(pdu.header_digest.is_none());

--- a/tests/unit_tests/test_text.rs
+++ b/tests/unit_tests/test_text.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2012-2025 Andrei Maltsev
 
-use std::fs;
 
 use anyhow::{Context, Result};
-use hex::FromHex;
 use iscsi_client_rs::{
     cfg::{cli::resolve_config_path, config::Config, enums::Digest},
     models::{
@@ -20,12 +18,7 @@ use iscsi_client_rs::{
 };
 use zerocopy::FromBytes as ZFromBytes;
 
-// Helper to load a hex fixture and decode it to a byte vector.
-fn load_fixture(path: &str) -> Result<Vec<u8>> {
-    let s = fs::read_to_string(path)?;
-    let cleaned = s.trim().replace(|c: char| c.is_whitespace(), "");
-    Ok(Vec::from_hex(&cleaned)?)
-}
+use crate::unit_tests::load_fixture;
 
 #[test]
 fn test_text_request() -> Result<()> {
@@ -37,7 +30,8 @@ fn test_text_request() -> Result<()> {
 
     let mut header_buf = [0u8; HEADER_LEN];
     header_buf.copy_from_slice(&bytes[..HEADER_LEN]);
-    let mut parsed_fixture = PDUWithData::<TextRequest>::from_header_slice(header_buf);
+    let mut parsed_fixture =
+        PDUWithData::<TextRequest>::from_header_slice(header_buf, &cfg);
     parsed_fixture.parse_with_buff(&bytes[HEADER_LEN..], false, false)?;
 
     let itt = 1;
@@ -54,8 +48,8 @@ fn test_text_request() -> Result<()> {
 
     let mut hdr_buf = [0u8; HEADER_LEN];
     header_builder.header.to_bhs_bytes(&mut hdr_buf)?;
-    let mut builder = PDUWithData::<TextRequest>::from_header_slice(hdr_buf);
-    builder.append_data(parsed_fixture.data.clone());
+    let mut builder = PDUWithData::<TextRequest>::from_header_slice(hdr_buf, &cfg);
+    builder.append_data(parsed_fixture.data()?);
 
     let (hdr_bytes, body_bytes) = &builder.build(
         cfg.login.negotiation.max_recv_data_segment_length as usize,
@@ -95,15 +89,18 @@ fn test_text_request() -> Result<()> {
 
 #[test]
 fn test_text_response() -> Result<()> {
+    let cfg =
+        resolve_config_path("tests/config.yaml").and_then(Config::load_from_file)?;
+
     let bytes = load_fixture("tests/unit_tests/fixtures/text/text_response.hex")?;
     assert!(bytes.len() >= HEADER_LEN);
 
     let mut header_buf = [0u8; HEADER_LEN];
     header_buf.copy_from_slice(&bytes[..HEADER_LEN]);
-    let mut parsed = PDUWithData::<TextResponse>::from_header_slice(header_buf);
+    let mut parsed = PDUWithData::<TextResponse>::from_header_slice(header_buf, &cfg);
     parsed.parse_with_buff(&bytes[HEADER_LEN..], false, false)?;
 
-    assert!(!parsed.data.is_empty());
+    assert!(!parsed.data()?.is_empty());
     assert!(parsed.header_digest.is_none());
     assert!(parsed.data_digest.is_none());
 
@@ -113,14 +110,15 @@ fn test_text_response() -> Result<()> {
     assert_eq!(op.opcode, Opcode::TextResp, "expected TextResp opcode");
 
     let data_size = hdr.get_data_length_bytes();
-    assert_eq!(data_size, parsed.data.len());
+    assert_eq!(data_size, parsed.data()?.len());
 
     assert_eq!(hdr.stat_sn.get(), 1939077135);
     assert_eq!(hdr.exp_cmd_sn.get(), 2);
 
     let expected =
         "TargetName=iqn.2025-07.com.example:target0\0TargetAddress=127.0.0.1:3260,1\0";
-    let actual = String::from_utf8(parsed.data).context("Failed to decode TEXT data")?;
+    let actual = String::from_utf8(parsed.data()?.to_vec())
+        .context("Failed to decode TEXT data")?;
     assert_eq!(expected.to_string(), actual);
 
     Ok(())

--- a/tests/unit_tests/test_write.rs
+++ b/tests/unit_tests/test_write.rs
@@ -58,8 +58,9 @@ fn test_write_pdu_build() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     header_builder.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut builder = PDUWithData::<ScsiCommandRequest>::from_header_slice(header_buf);
-    builder.append_data(write_buf);
+    let mut builder =
+        PDUWithData::<ScsiCommandRequest>::from_header_slice(header_buf, &cfg);
+    builder.append_data(write_buf.as_slice());
 
     let hd = cfg.login.negotiation.header_digest == Digest::CRC32C;
     let dd = cfg.login.negotiation.data_digest == Digest::CRC32C;
@@ -96,10 +97,10 @@ fn test_write_response_parse() -> Result<()> {
     let mut hdr_buf = [0u8; HEADER_LEN];
     hdr_buf.copy_from_slice(&bytes[..HEADER_LEN]);
 
-    let mut pdu = PDUWithData::<ScsiCommandResponse>::from_header_slice(hdr_buf);
+    let mut pdu = PDUWithData::<ScsiCommandResponse>::from_header_slice(hdr_buf, &cfg);
     pdu.parse_with_buff(&bytes[HEADER_LEN..], hd, dd)?;
 
-    assert!(pdu.data.is_empty());
+    assert!(pdu.data()?.is_empty());
     assert!(pdu.header_digest.is_none());
     assert!(pdu.data_digest.is_none());
 

--- a/tests/unit_tests/test_write.rs
+++ b/tests/unit_tests/test_write.rs
@@ -4,6 +4,7 @@
 use std::fs;
 
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use hex::FromHex;
 use iscsi_client_rs::{
     cfg::{cli::resolve_config_path, config::Config, enums::Digest},
@@ -15,7 +16,7 @@ use iscsi_client_rs::{
             response::ScsiCommandResponse,
         },
         common::{Builder, HEADER_LEN},
-        data_fromat::PDUWithData,
+        data_fromat::{PDUWithData, PduRequest},
     },
 };
 
@@ -58,8 +59,7 @@ fn test_write_pdu_build() -> Result<()> {
     let mut header_buf = [0u8; HEADER_LEN];
     header_builder.header.to_bhs_bytes(&mut header_buf)?;
 
-    let mut builder =
-        PDUWithData::<ScsiCommandRequest>::from_header_slice(header_buf, &cfg);
+    let mut builder = PduRequest::<ScsiCommandRequest>::new_request(header_buf, &cfg);
     builder.append_data(write_buf.as_slice());
 
     let hd = cfg.login.negotiation.header_digest == Digest::CRC32C;
@@ -98,7 +98,7 @@ fn test_write_response_parse() -> Result<()> {
     hdr_buf.copy_from_slice(&bytes[..HEADER_LEN]);
 
     let mut pdu = PDUWithData::<ScsiCommandResponse>::from_header_slice(hdr_buf, &cfg);
-    pdu.parse_with_buff(&bytes[HEADER_LEN..], hd, dd)?;
+    pdu.parse_with_buff(&Bytes::copy_from_slice(&bytes[HEADER_LEN..]), hd, dd)?;
 
     assert!(pdu.data()?.is_empty());
     assert!(pdu.header_digest.is_none());


### PR DESCRIPTION
Now pdu payload(additional header segment + header digest + data + data digest) writes to bytes/bytesMut. In future, we can store BytesMut in global memory pool, and reduce heap allocations for payload. Also was added split between PduRequest/Response, so during reading it make more sense
