### PR TITLE
fix: tcp poisoned connections could not restore

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -15,6 +15,7 @@ use std::{
 use anyhow::{Result, anyhow, bail};
 use once_cell::sync::OnceCell;
 use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
     net::{
         TcpStream,
         tcp::{OwnedReadHalf, OwnedWriteHalf},
@@ -114,6 +115,78 @@ impl ClientConnection {
 
     pub fn bind_pool_session(&self, pool: Weak<Pool>, tsih: u16, cid: u16) {
         let _ = self.session_ref.set(SessionRef { pool, tsih, cid });
+    }
+
+    #[inline]
+    pub(super) fn ensure_active(&self) -> Result<()> {
+        if self.is_poisoned() {
+            bail!("connection poisoned");
+        }
+        if self.cancel.is_cancelled() {
+            bail!("cancelled");
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub(super) fn ensure_writable(&self) -> Result<()> {
+        self.ensure_active()?;
+        if self.stop_writes.is_cancelled() {
+            bail!("writes are quiesced");
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub(super) fn digest_flags(&self) -> (bool, bool) {
+        (
+            self.cfg.login.integrity.header_digest == crate::cfg::enums::Digest::CRC32C,
+            self.cfg.login.integrity.data_digest == crate::cfg::enums::Digest::CRC32C,
+        )
+    }
+
+    pub(super) async fn read_exact_with_timeout(
+        &self,
+        reader: &mut OwnedReadHalf,
+        buf: &mut [u8],
+        label: &'static str,
+    ) -> Result<()> {
+        io_with_timeout(
+            label,
+            reader.read_exact(buf),
+            self.cfg.runtime.timeout_connection,
+            &self.cancel,
+        )
+        .await
+        .map_err(|error| {
+            if is_timeout_error(&error) {
+                self.poison(format!("{label} timeout: {error}"));
+            }
+            error
+        })?;
+        Ok(())
+    }
+
+    pub(super) async fn write_all_with_timeout(
+        &self,
+        writer: &mut OwnedWriteHalf,
+        buf: &[u8],
+        label: &'static str,
+    ) -> Result<()> {
+        io_with_timeout(
+            label,
+            writer.write_all(buf),
+            self.cfg.runtime.timeout_connection,
+            &self.cancel,
+        )
+        .await
+        .map_err(|error| {
+            if is_timeout_error(&error) {
+                self.poison(format!("{label} timeout: {error}"));
+            }
+            error
+        })?;
+        Ok(())
     }
 
     #[inline]

--- a/src/client/client/read.rs
+++ b/src/client/client/read.rs
@@ -5,16 +5,11 @@ use std::{any::type_name, fmt::Debug, sync::Arc};
 
 use anyhow::{Result, anyhow, bail};
 use bytes::{Bytes, BytesMut};
-use tokio::io::AsyncReadExt;
 use tracing::{debug, warn};
 
 use super::ClientConnection;
 use crate::{
-    cfg::enums::Digest,
-    client::{
-        common::{RawPdu, io_with_timeout, is_timeout_error},
-        pdu_connection::FromBytes,
-    },
+    client::{common::RawPdu, pdu_connection::FromBytes},
     models::{
         common::{BasicHeaderSegment, HEADER_LEN, SendingData},
         data_fromat::{PduResponse, ZeroCopyType},
@@ -28,9 +23,7 @@ impl ClientConnection {
         &self,
         initiator_task_tag: u32,
     ) -> Result<(PduResponse<T>, Bytes)> {
-        if self.is_poisoned() {
-            bail!("connection poisoned");
-        }
+        self.ensure_active()?;
         let mut receiver = self.pending.take_receiver(initiator_task_tag)?;
 
         let RawPdu {
@@ -67,7 +60,10 @@ impl ClientConnection {
         initiator_task_tag: u32,
     ) -> Result<PduResponse<T>> {
         let (mut pdu, data) = self.read_response_raw(initiator_task_tag).await?;
-        pdu.parse_with_buff(&data)?;
+        if let Err(error) = pdu.parse_with_buff(&data) {
+            self.poison(format!("invalid response PDU: {error}"));
+            return Err(error);
+        }
         Ok(pdu)
     }
 
@@ -99,34 +95,24 @@ impl ClientConnection {
     }
 
     async fn read_pdu(&self, scratch: &mut BytesMut) -> Result<(u32, bool, RawPdu)> {
-        if self.is_poisoned() {
-            bail!("connection poisoned");
-        }
+        self.ensure_active()?;
         scratch.clear();
         scratch.resize(HEADER_LEN, 0);
 
         let mut reader = self.reader.lock().await;
-        io_with_timeout(
+        self.read_exact_with_timeout(
+            &mut reader,
+            &mut scratch[..HEADER_LEN],
             "read header",
-            reader.read_exact(&mut scratch[..HEADER_LEN]),
-            self.cfg.runtime.timeout_connection,
-            &self.cancel,
         )
-        .await
-        .map_err(|error| {
-            if is_timeout_error(&error) {
-                self.poison(format!("read header timeout: {error}"));
-            }
-            error
-        })?;
+        .await?;
 
         let header = Pdu::from_bhs_bytes(&mut scratch[..HEADER_LEN])?;
         debug!("RECV BHS: {header:?}");
 
         let itt = header.get_initiator_task_tag();
         let is_final = header.get_final_bit();
-        let header_digest = self.cfg.login.integrity.header_digest == Digest::CRC32C;
-        let data_digest = self.cfg.login.integrity.data_digest == Digest::CRC32C;
+        let (header_digest, data_digest) = self.digest_flags();
         let data_length = header.total_length_bytes();
         let data_digest_length = if data_length > HEADER_LEN {
             header.get_data_diggest(data_digest)
@@ -138,19 +124,12 @@ impl ClientConnection {
 
         scratch.resize(total_length, 0);
         if total_length > HEADER_LEN {
-            io_with_timeout(
+            self.read_exact_with_timeout(
+                &mut reader,
+                &mut scratch[HEADER_LEN..],
                 "read payload",
-                reader.read_exact(&mut scratch[HEADER_LEN..]),
-                self.cfg.runtime.timeout_connection,
-                &self.cancel,
             )
-            .await
-            .map_err(|error| {
-                if is_timeout_error(&error) {
-                    self.poison(format!("read payload timeout: {error}"));
-                }
-                error
-            })?;
+            .await?;
         }
         drop(reader);
 

--- a/src/client/client/write.rs
+++ b/src/client/client/write.rs
@@ -3,19 +3,13 @@
 
 use std::{fmt, fmt::Debug};
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use bytes::Bytes;
 use tokio::io::AsyncWriteExt;
 use tracing::debug;
 
 use super::ClientConnection;
-use crate::{
-    client::{
-        common::{io_with_timeout, is_timeout_error},
-        pdu_connection::ToBytes,
-    },
-    models::common::HEADER_LEN,
-};
+use crate::{client::pdu_connection::ToBytes, models::common::HEADER_LEN};
 
 impl ClientConnection {
     /// Optionally half-close the write side (send FIN). This is irreversible.
@@ -31,12 +25,7 @@ impl ClientConnection {
         &self,
         mut request: impl ToBytes<Header = [u8; HEADER_LEN], Body = Bytes> + fmt::Debug,
     ) -> Result<()> {
-        if self.is_poisoned() {
-            bail!("connection poisoned",);
-        }
-        if self.cancel.is_cancelled() {
-            bail!("cancelled");
-        }
+        self.ensure_writable()?;
 
         let mut writer = self.writer.lock().await;
         let (header, data) = request
@@ -44,34 +33,12 @@ impl ClientConnection {
         debug!("SEND {request:?}");
         debug!("Size_header: {} Size_data: {}", header.len(), data.len());
 
-        io_with_timeout(
-            "write header (write_all)",
-            writer.write_all(&header),
-            self.cfg.runtime.timeout_connection,
-            &self.cancel,
-        )
-        .await
-        .map_err(|error| {
-            if is_timeout_error(&error) {
-                self.poison(format!("write header timeout: {error}"));
-            }
-            error
-        })?;
+        self.write_all_with_timeout(&mut writer, &header, "write header")
+            .await?;
 
         if !data.is_empty() {
-            io_with_timeout(
-                "write data (write_all)",
-                writer.write_all(&data),
-                self.cfg.runtime.timeout_connection,
-                &self.cancel,
-            )
-            .await
-            .map_err(|error| {
-                if is_timeout_error(&error) {
-                    self.poison(format!("write data timeout: {error}"));
-                }
-                error
-            })?;
+            self.write_all_with_timeout(&mut writer, &data, "write data")
+                .await?;
         }
 
         Ok(())
@@ -82,12 +49,7 @@ impl ClientConnection {
         initiator_task_tag: u32,
         request: impl ToBytes<Header = [u8; HEADER_LEN], Body = Bytes> + Debug,
     ) -> Result<()> {
-        if self.is_poisoned() {
-            bail!("connection poisoned");
-        }
-        if self.cancel.is_cancelled() {
-            bail!("cancelled");
-        }
+        self.ensure_writable()?;
 
         let expects_response = initiator_task_tag != u32::MAX;
         if expects_response {

--- a/src/client/pool_sessions.rs
+++ b/src/client/pool_sessions.rs
@@ -219,21 +219,34 @@ impl Pool {
         let target_name = sess.target_name.clone();
         let isid = sess.isid;
         let cfg = expected.conn.cfg.clone();
+        let mut removed = None;
 
         if let Some(current) = sess.conns.get(&cid).map(|entry| entry.clone()) {
             if Arc::ptr_eq(&current, &expected) || current.conn.is_poisoned() {
-                sess.conns.remove(&cid);
+                removed = sess.conns.remove(&cid).map(|(_, conn)| conn);
             } else {
                 return Ok(());
             }
         }
 
         let child = self.cancel.child_token();
-        let conn = ClientConnection::connect(cfg, child).await?;
-        let _ = self
-            .login_one_and_insert_impl(target_name, isid, tsih, cid, conn)
-            .await?;
-        Ok(())
+        let recovery = async {
+            let conn = ClientConnection::connect(cfg, child).await?;
+            let _ = self
+                .login_one_and_insert_impl(target_name, isid, tsih, cid, conn)
+                .await?;
+            Ok(())
+        }
+        .await;
+
+        if recovery.is_err()
+            && let Some(previous) = removed
+            && sess.conns.get(&cid).is_none()
+        {
+            sess.conns.insert(cid, previous);
+        }
+
+        recovery
     }
 
     async fn login_one_and_insert_impl(

--- a/src/state_machine/login/common.rs
+++ b/src/state_machine/login/common.rs
@@ -183,8 +183,10 @@ pub(crate) fn verify_operational_negotiation(
     match header.flags.nsg() {
         Some(Stage::FullFeature) => {},
         other => bail!(
-            "login response NSG={other:?} (expected {:?})",
-            Stage::FullFeature
+            "login response NSG={other:?} (expected {:?}), status={:?}/{:?}",
+            Stage::FullFeature,
+            header.status_class,
+            header.status_detail,
         ),
     }
 

--- a/tests/_integration_entry.rs
+++ b/tests/_integration_entry.rs
@@ -7,11 +7,16 @@ mod integration_tests {
     pub mod common;
 
     pub mod check_tur;
+    pub mod client_faults;
+    pub mod concurrent_io;
+    pub mod io_boundaries;
     pub mod login_chap_ok;
+    pub mod login_negative;
     pub mod login_plain_ok;
     pub mod logout_ok;
     pub mod mod_sense;
     pub mod read_sense;
+    pub mod recovery;
     pub mod report_luns;
 
     //inquiry

--- a/tests/integration_tests/client_faults.rs
+++ b/tests/integration_tests/client_faults.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2012-2025 Andrei Maltsev
+
+use std::{fs, time::Duration};
+
+use anyhow::{Context, Result};
+use hex::FromHex;
+use iscsi_client_rs::{
+    cfg::{config::Config, enums::Digest},
+    client::client::ClientConnection,
+    models::{
+        common::HEADER_LEN,
+        data_fromat::PduRequest,
+        nop::{
+            request::{NopOutRequest, NopOutRequestBuilder},
+            response::NopInResponse,
+        },
+    },
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    time::{sleep, timeout},
+};
+use tokio_util::sync::CancellationToken;
+
+fn load_fixture(path: &str) -> Result<Vec<u8>> {
+    let s = fs::read_to_string(path)?;
+    let cleaned = s.trim().replace(|c: char| c.is_whitespace(), "");
+    Ok(Vec::from_hex(&cleaned)?)
+}
+
+fn test_config(
+    target_address: String,
+    timeout_connection: Duration,
+    digest: Digest,
+) -> Result<Config> {
+    let mut cfg = Config::load_from_file("tests/configs/tgt/plain.yaml")?;
+    cfg.login.transport.target_address = target_address;
+    cfg.login.integrity.header_digest = digest;
+    cfg.login.integrity.data_digest = digest;
+    cfg.runtime.timeout_connection = timeout_connection;
+    Ok(cfg)
+}
+
+async fn wait_until_poisoned(conn: &ClientConnection) -> Result<()> {
+    timeout(Duration::from_secs(1), async {
+        while !conn.is_poisoned() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .context("connection was not poisoned")?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn eof_before_bhs_poisons_connection() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept");
+        drop(stream);
+    });
+
+    let cfg = test_config(
+        address.to_string(),
+        Duration::from_millis(100),
+        Digest::None,
+    )?;
+    let conn = ClientConnection::connect(cfg, CancellationToken::new()).await?;
+
+    wait_until_poisoned(&conn).await?;
+    server.await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn truncated_bhs_poisons_connection() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept");
+        stream.write_all(&[0x20; 12]).await.expect("partial BHS");
+    });
+
+    let cfg = test_config(
+        address.to_string(),
+        Duration::from_millis(100),
+        Digest::None,
+    )?;
+    let conn = ClientConnection::connect(cfg, CancellationToken::new()).await?;
+
+    wait_until_poisoned(&conn).await?;
+    server.await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn truncated_payload_poisons_connection() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept");
+        let mut header = [0u8; HEADER_LEN];
+        header[0] = 0x20;
+        header[5..8].copy_from_slice(&[0, 0, 8]);
+        stream.write_all(&header).await.expect("BHS");
+        stream.write_all(&[1, 2, 3]).await.expect("partial payload");
+    });
+
+    let cfg = test_config(
+        address.to_string(),
+        Duration::from_millis(100),
+        Digest::None,
+    )?;
+    let conn = ClientConnection::connect(cfg, CancellationToken::new()).await?;
+
+    wait_until_poisoned(&conn).await?;
+    server.await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn read_timeout_poisons_connection() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        let (_stream, _) = listener.accept().await.expect("accept");
+        sleep(Duration::from_secs(1)).await;
+    });
+
+    let cfg = test_config(address.to_string(), Duration::from_millis(50), Digest::None)?;
+    let conn = ClientConnection::connect(cfg, CancellationToken::new()).await?;
+
+    wait_until_poisoned(&conn).await?;
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_header_digest_poisons_connection() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let mut response = load_fixture("tests/unit_tests/fixtures/nop/nop_in_response.hex")?;
+    response.truncate(HEADER_LEN);
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept");
+        let mut request = [0u8; HEADER_LEN + 4];
+        stream.read_exact(&mut request).await.expect("NOP-Out");
+        response[16..20].copy_from_slice(&request[16..20]);
+        stream.write_all(&response).await.expect("NOP-In BHS");
+        stream
+            .write_all(&0xdead_beefu32.to_le_bytes())
+            .await
+            .expect("bad HeaderDigest");
+        sleep(Duration::from_millis(100)).await;
+    });
+
+    let mut cfg = Config::load_from_file("tests/configs/tgt/crc.yaml")?;
+    cfg.login.transport.target_address = address.to_string();
+    cfg.runtime.timeout_connection = Duration::from_millis(200);
+    let conn = ClientConnection::connect(cfg.clone(), CancellationToken::new()).await?;
+
+    let itt = 42;
+    let header = NopOutRequestBuilder::new()
+        .initiator_task_tag(itt)
+        .target_task_tag(NopOutRequest::DEFAULT_TAG)
+        .immediate();
+    let mut header_buf = [0u8; HEADER_LEN];
+    header.header.to_bhs_bytes(&mut header_buf)?;
+    let request = PduRequest::<NopOutRequest>::new_request(header_buf, &cfg);
+    conn.send_request(itt, request).await?;
+
+    let error = conn
+        .read_response::<NopInResponse>(itt)
+        .await
+        .expect_err("invalid digest must fail");
+    assert!(error.to_string().contains("HeaderDigest mismatch"));
+    assert!(conn.is_poisoned());
+    server.await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_data_digest_poisons_connection() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let mut response = load_fixture("tests/unit_tests/fixtures/nop/nop_in_response.hex")?;
+    response.truncate(HEADER_LEN);
+    response[5..8].copy_from_slice(&[0, 0, 4]);
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept");
+        let mut request = [0u8; HEADER_LEN + 4];
+        stream.read_exact(&mut request).await.expect("NOP-Out");
+        response[16..20].copy_from_slice(&request[16..20]);
+
+        let header_digest = crc32c::crc32c(&response).to_le_bytes();
+        stream.write_all(&response).await.expect("NOP-In BHS");
+        stream
+            .write_all(&header_digest)
+            .await
+            .expect("HeaderDigest");
+        stream.write_all(b"ping").await.expect("NOP-In data");
+        stream
+            .write_all(&0xdead_beefu32.to_le_bytes())
+            .await
+            .expect("bad DataDigest");
+        sleep(Duration::from_millis(100)).await;
+    });
+
+    let mut cfg = Config::load_from_file("tests/configs/tgt/crc.yaml")?;
+    cfg.login.transport.target_address = address.to_string();
+    cfg.runtime.timeout_connection = Duration::from_millis(200);
+    let conn = ClientConnection::connect(cfg.clone(), CancellationToken::new()).await?;
+
+    let itt = 43;
+    let header = NopOutRequestBuilder::new()
+        .initiator_task_tag(itt)
+        .target_task_tag(NopOutRequest::DEFAULT_TAG)
+        .immediate();
+    let mut header_buf = [0u8; HEADER_LEN];
+    header.header.to_bhs_bytes(&mut header_buf)?;
+    let request = PduRequest::<NopOutRequest>::new_request(header_buf, &cfg);
+    conn.send_request(itt, request).await?;
+
+    let error = conn
+        .read_response::<NopInResponse>(itt)
+        .await
+        .expect_err("invalid digest must fail");
+    assert!(error.to_string().contains("DataDigest mismatch"));
+    assert!(conn.is_poisoned());
+    server.await?;
+    Ok(())
+}

--- a/tests/integration_tests/concurrent_io.rs
+++ b/tests/integration_tests/concurrent_io.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2012-2025 Andrei Maltsev
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::{Context, Result};
+use iscsi_client_rs::{
+    cfg::logger::init_logger,
+    client::pool_sessions::Pool,
+    control_block::{
+        read::build_read10,
+        read_capacity::{build_read_capacity10, parse_read_capacity10_zerocopy},
+        write::build_write10,
+    },
+    state_machine::{read_states::ReadCtx, tur_states::TurCtx, write_states::WriteCtx},
+};
+use serial_test::serial;
+
+use crate::integration_tests::common::{
+    connect_cfg, get_lun, load_config, test_isid, test_path,
+};
+
+const REQUESTS: u32 = 32;
+const START_LBA: u32 = 16_384;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[serial]
+async fn concurrent_writes_and_reads_share_one_connection() -> Result<()> {
+    let _ = init_logger(&test_path());
+    let cfg = Arc::new(load_config()?);
+    let pool = Arc::new(Pool::new(&cfg));
+    pool.attach_self();
+
+    let conn = connect_cfg(&cfg).await?;
+    let target_name: Arc<str> = Arc::from(cfg.login.identity.target_name.clone());
+    let tsih = pool
+        .login_and_insert(target_name, test_isid(), 0, conn)
+        .await
+        .context("pool login failed")?;
+    let lun = get_lun();
+    let _ = pool
+        .execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+            TurCtx::new(c, itt, cmd_sn, exp_stat_sn, lun)
+        })
+        .await;
+    pool.execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+        TurCtx::new(c, itt, cmd_sn, exp_stat_sn, lun)
+    })
+    .await
+    .context("TUR failed")?;
+
+    let capacity = pool
+        .execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+            let mut cdb = [0u8; 16];
+            build_read_capacity10(&mut cdb, 0, false, 0);
+            ReadCtx::new(c, lun, itt, cmd_sn, exp_stat_sn, 8, cdb)
+        })
+        .await?;
+    let block_size = parse_read_capacity10_zerocopy(&capacity.data)?
+        .block_len
+        .get() as usize;
+
+    let mut writes = Vec::with_capacity(REQUESTS as usize);
+    for index in 0..REQUESTS {
+        let pool = Arc::clone(&pool);
+        let payload = vec![(index as u8).wrapping_mul(17); block_size];
+        writes.push(tokio::spawn(async move {
+            pool.execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+                let mut cdb = [0u8; 16];
+                build_write10(&mut cdb, START_LBA + index, 1, 0, 0);
+                WriteCtx::new(c, lun, itt, cmd_sn, exp_stat_sn, cdb, payload.clone())
+            })
+            .await
+        }));
+    }
+    for write in writes {
+        write.await.context("write task panicked")??;
+    }
+
+    let mut reads = Vec::with_capacity(REQUESTS as usize);
+    for index in 0..REQUESTS {
+        let pool = Arc::clone(&pool);
+        reads.push(tokio::spawn(async move {
+            let result = pool
+                .execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+                    let mut cdb = [0u8; 16];
+                    build_read10(&mut cdb, START_LBA + index, 1, 0, 0);
+                    ReadCtx::new(c, lun, itt, cmd_sn, exp_stat_sn, block_size as u32, cdb)
+                })
+                .await?;
+            let expected = vec![(index as u8).wrapping_mul(17); block_size];
+            anyhow::ensure!(
+                result.data == expected,
+                "payload mismatch for request {index}"
+            );
+            Ok::<(), anyhow::Error>(())
+        }));
+    }
+    for read in reads {
+        read.await.context("read task panicked")??;
+    }
+
+    pool.shutdown_gracefully(Duration::from_secs(10)).await
+}

--- a/tests/integration_tests/io_boundaries.rs
+++ b/tests/integration_tests/io_boundaries.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2012-2025 Andrei Maltsev
+
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+
+use anyhow::{Context, Result};
+use iscsi_client_rs::{
+    cfg::logger::init_logger,
+    client::pool_sessions::Pool,
+    control_block::{
+        read::build_read10,
+        read_capacity::{build_read_capacity10, parse_read_capacity10_zerocopy},
+        write::build_write10,
+    },
+    state_machine::{read_states::ReadCtx, tur_states::TurCtx, write_states::WriteCtx},
+};
+use serial_test::serial;
+
+use crate::integration_tests::common::{
+    connect_cfg, get_lun, load_config, test_isid, test_path,
+};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn io_around_negotiated_segment_boundaries() -> Result<()> {
+    let _ = init_logger(&test_path());
+    let cfg = Arc::new(load_config()?);
+    let pool = Arc::new(Pool::new(&cfg));
+    pool.attach_self();
+
+    let conn = connect_cfg(&cfg).await?;
+    let target_name: Arc<str> = Arc::from(cfg.login.identity.target_name.clone());
+    let tsih = pool
+        .login_and_insert(target_name, test_isid(), 0, conn)
+        .await
+        .context("pool login failed")?;
+    let lun = get_lun();
+    let _ = pool
+        .execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+            TurCtx::new(c, itt, cmd_sn, exp_stat_sn, lun)
+        })
+        .await;
+    pool.execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+        TurCtx::new(c, itt, cmd_sn, exp_stat_sn, lun)
+    })
+    .await
+    .context("TUR failed")?;
+
+    let capacity = pool
+        .execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+            let mut cdb = [0u8; 16];
+            build_read_capacity10(&mut cdb, 0, false, 0);
+            ReadCtx::new(c, lun, itt, cmd_sn, exp_stat_sn, 8, cdb)
+        })
+        .await?;
+    let block_size = parse_read_capacity10_zerocopy(&capacity.data)?
+        .block_len
+        .get() as usize;
+
+    let first_burst_blocks = cfg.login.flow.first_burst_length as usize / block_size;
+    let segment_blocks =
+        cfg.login.flow.max_recv_data_segment_length as usize / block_size;
+    let mut block_counts = BTreeSet::from([1usize]);
+    for boundary in [first_burst_blocks, segment_blocks] {
+        if boundary > 1 {
+            block_counts.insert(boundary - 1);
+        }
+        block_counts.insert(boundary);
+        block_counts.insert(boundary + 1);
+    }
+
+    let mut lba = 20_000u32;
+    for blocks in block_counts {
+        anyhow::ensure!(blocks <= u16::MAX as usize);
+        let byte_len = blocks * block_size;
+        let payload = (0..byte_len)
+            .map(|offset| (offset as u8).wrapping_add(blocks as u8))
+            .collect::<Vec<_>>();
+
+        pool.execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+            let mut cdb = [0u8; 16];
+            build_write10(&mut cdb, lba, blocks as u16, 0, 0);
+            WriteCtx::new(c, lun, itt, cmd_sn, exp_stat_sn, cdb, payload.clone())
+        })
+        .await
+        .with_context(|| format!("WRITE boundary blocks={blocks}"))?;
+
+        let read = pool
+            .execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+                let mut cdb = [0u8; 16];
+                build_read10(&mut cdb, lba, blocks as u16, 0, 0);
+                ReadCtx::new(c, lun, itt, cmd_sn, exp_stat_sn, byte_len as u32, cdb)
+            })
+            .await
+            .with_context(|| format!("READ boundary blocks={blocks}"))?;
+        assert_eq!(read.data, payload, "boundary payload mismatch");
+        lba += blocks as u32 + 8;
+    }
+
+    pool.shutdown_gracefully(Duration::from_secs(10)).await
+}

--- a/tests/integration_tests/io_boundaries.rs
+++ b/tests/integration_tests/io_boundaries.rs
@@ -66,7 +66,9 @@ async fn io_around_negotiated_segment_boundaries() -> Result<()> {
             block_counts.insert(boundary - 1);
         }
         block_counts.insert(boundary);
-        block_counts.insert(boundary + 1);
+    }
+    if first_burst_blocks > 0 {
+        block_counts.insert(first_burst_blocks + 1);
     }
 
     let mut lba = 20_000u32;

--- a/tests/integration_tests/login_negative.rs
+++ b/tests/integration_tests/login_negative.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2012-2025 Andrei Maltsev
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use iscsi_client_rs::{
+    cfg::{
+        config::{AuthConfig, ChapConfig, Config},
+        logger::init_logger,
+    },
+    client::pool_sessions::Pool,
+};
+
+use crate::integration_tests::common::{connect_cfg, load_config, test_isid, test_path};
+
+async fn assert_login_rejected(cfg: Config, isid_suffix: u8) -> Result<()> {
+    let pool = Arc::new(Pool::new(&cfg));
+    pool.attach_self();
+    let conn = connect_cfg(&cfg).await?;
+    let target_name: Arc<str> = Arc::from(cfg.login.identity.target_name.clone());
+    let mut isid = test_isid();
+    isid[5] = isid_suffix;
+
+    let result = pool.login_and_insert(target_name, isid, 0, conn).await;
+    assert!(
+        result.is_err(),
+        "invalid authentication unexpectedly succeeded"
+    );
+    assert!(pool.sessions.is_empty(), "failed login entered the pool");
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_authentication_is_rejected() -> Result<()> {
+    let _ = init_logger(&test_path());
+    let cfg = load_config()?;
+
+    match &cfg.login.auth {
+        AuthConfig::Chap(chap) => {
+            let mut wrong_secret = cfg.clone();
+            wrong_secret.login.auth = AuthConfig::Chap(ChapConfig {
+                username: chap.username.clone(),
+                secret: "definitely-wrong-secret".into(),
+            });
+            assert_login_rejected(wrong_secret, 31).await?;
+
+            let mut wrong_user = cfg.clone();
+            wrong_user.login.auth = AuthConfig::Chap(ChapConfig {
+                username: "unknown-user".into(),
+                secret: chap.secret.clone(),
+            });
+            assert_login_rejected(wrong_user, 32).await?;
+
+            let mut missing_chap = cfg;
+            missing_chap.login.auth = AuthConfig::None;
+            assert_login_rejected(missing_chap, 33).await?;
+        },
+        AuthConfig::None => {
+            let mut unexpected_chap = cfg;
+            unexpected_chap.login.auth = AuthConfig::Chap(ChapConfig {
+                username: "testuser".into(),
+                secret: "secretpass".into(),
+            });
+            assert_login_rejected(unexpected_chap, 34).await?;
+        },
+    }
+
+    Ok(())
+}

--- a/tests/integration_tests/recovery.rs
+++ b/tests/integration_tests/recovery.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2012-2025 Andrei Maltsev
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::{Context, Result};
+use iscsi_client_rs::{
+    cfg::{
+        config::{Config, login_keys_operational},
+        logger::init_logger,
+    },
+    client::{client::ClientConnection, pool_sessions::Pool},
+    models::{
+        common::{BasicHeaderSegment, HEADER_LEN},
+        login::{
+            common::Stage,
+            request::LoginRequest,
+            response::LoginResponse,
+            status::{RawStatusPair, StatusClass, StatusDetail, SuccessDetail},
+        },
+        nop::{request::NopOutRequest, response::NopInResponse},
+        opcode::{Opcode, RawBhsOpcode},
+    },
+    state_machine::nop_states::NopCtx,
+};
+use serial_test::serial;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    time::sleep,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::integration_tests::common::{test_isid, test_path};
+
+const TEST_TSIH: u16 = 0x0200;
+
+fn load_plain_cfg(target_address: String) -> Result<Config> {
+    let mut cfg = Config::load_from_file("tests/configs/tgt/plain.yaml")?;
+    cfg.login.transport.target_address = target_address;
+    cfg.runtime.timeout_connection = Duration::from_millis(300);
+    Ok(cfg)
+}
+
+async fn read_frame(stream: &mut TcpStream) -> Result<([u8; HEADER_LEN], Vec<u8>)> {
+    let mut header = [0u8; HEADER_LEN];
+    stream.read_exact(&mut header).await?;
+
+    let data_len = u32::from_be_bytes([0, header[5], header[6], header[7]]) as usize;
+    let padded_len = data_len.next_multiple_of(4);
+    let mut payload = vec![0u8; padded_len];
+    if padded_len != 0 {
+        stream.read_exact(&mut payload).await?;
+        payload.truncate(data_len);
+    }
+
+    Ok((header, payload))
+}
+
+async fn write_frame(
+    stream: &mut TcpStream,
+    header: &[u8; HEADER_LEN],
+    payload: &[u8],
+) -> Result<()> {
+    stream.write_all(header).await?;
+    if !payload.is_empty() {
+        stream.write_all(payload).await?;
+        let padding = [0u8; 3];
+        let pad_len = (4 - (payload.len() % 4)) % 4;
+        if pad_len != 0 {
+            stream.write_all(&padding[..pad_len]).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn write_login_response(
+    stream: &mut TcpStream,
+    cfg: &Config,
+    request_header: [u8; HEADER_LEN],
+    tsih: u16,
+) -> Result<()> {
+    let mut request_header = request_header;
+    let request = LoginRequest::from_bhs_bytes(&mut request_header)?;
+
+    let mut response = LoginResponse::default();
+    response.opcode = {
+        let mut opcode = RawBhsOpcode::default();
+        opcode.set_opcode_known(Opcode::LoginResp);
+        opcode
+    };
+    response.flags.set_transit(true);
+    response.flags.set_csg(Stage::Operational);
+    response.flags.set_nsg(Stage::FullFeature);
+    response.version_max = request.version_max;
+    response.version_active = request.version_max;
+    response.isid = request.isid;
+    response.tsih.set(tsih);
+    response
+        .initiator_task_tag
+        .set(request.initiator_task_tag.get());
+    response.stat_sn.set(0);
+    response
+        .exp_cmd_sn
+        .set(request.cmd_sn.get().wrapping_add(1));
+    response
+        .max_cmd_sn
+        .set(request.cmd_sn.get().wrapping_add(1));
+
+    let mut status = RawStatusPair::new();
+    status.encode(
+        StatusClass::Success,
+        StatusDetail::Success(SuccessDetail::CmdCompletedNormally),
+    )?;
+    response.status_class = status.class;
+    response.status_detail = status.detail;
+
+    let payload = login_keys_operational(cfg);
+    response.set_data_length_bytes(payload.len() as u32);
+
+    let mut header = [0u8; HEADER_LEN];
+    response.to_bhs_bytes(&mut header)?;
+    write_frame(stream, &header, &payload).await
+}
+
+async fn write_nop_in(
+    stream: &mut TcpStream,
+    request_header: [u8; HEADER_LEN],
+) -> Result<()> {
+    let mut request_header = request_header;
+    let request = NopOutRequest::from_bhs_bytes(&mut request_header)?;
+
+    let mut response = NopInResponse::default();
+    response.opcode = {
+        let mut opcode = RawBhsOpcode::default();
+        opcode.set_opcode_known(Opcode::NopIn);
+        opcode
+    };
+    response.lun.set(request.lun.get());
+    response
+        .initiator_task_tag
+        .set(request.initiator_task_tag.get());
+    response.target_task_tag.set(NopOutRequest::DEFAULT_TAG);
+    response.stat_sn.set(1);
+    response
+        .exp_cmd_sn
+        .set(request.cmd_sn.get().wrapping_add(1));
+    response
+        .max_cmd_sn
+        .set(request.cmd_sn.get().wrapping_add(1));
+
+    let mut header = [0u8; HEADER_LEN];
+    response.to_bhs_bytes(&mut header)?;
+    write_frame(stream, &header, &[]).await
+}
+
+async fn serve_recovery_target(listener: TcpListener, cfg: Config) -> Result<()> {
+    let (mut first, _) = listener.accept().await?;
+    let (login1, _) = read_frame(&mut first).await?;
+    write_login_response(&mut first, &cfg, login1, TEST_TSIH).await?;
+    let (_nop1, _) = read_frame(&mut first).await?;
+    let stalled = tokio::spawn(async move {
+        sleep(Duration::from_millis(700)).await;
+        drop(first);
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let (mut second, _) = listener.accept().await?;
+    let (login2, _) = read_frame(&mut second).await?;
+    write_login_response(&mut second, &cfg, login2, TEST_TSIH).await?;
+    let (nop2, _) = read_frame(&mut second).await?;
+    write_nop_in(&mut second, nop2).await?;
+    sleep(Duration::from_millis(100)).await;
+    stalled.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn poisoned_connection_is_recreated_after_timeout() -> Result<()> {
+    let _ = init_logger(&test_path());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let cfg = load_plain_cfg(address.to_string())?;
+
+    let server = tokio::spawn(serve_recovery_target(listener, cfg.clone()));
+    let pool = Arc::new(Pool::new(&cfg));
+    pool.attach_self();
+
+    let conn = ClientConnection::connect(cfg.clone(), CancellationToken::new()).await?;
+    let target_name: Arc<str> = Arc::from(cfg.login.identity.target_name.clone());
+    let tsih = pool
+        .login_and_insert(target_name, test_isid(), 0, conn)
+        .await
+        .context("pool login failed")?;
+
+    let before = pool
+        .sessions
+        .get(&tsih)
+        .context("missing session after login")?
+        .conns
+        .get(&0)
+        .context("missing CID=0 after login")?
+        .conn
+        .clone();
+
+    pool.execute_with(tsih, 0, |c, itt, cmd_sn, exp_stat_sn| {
+        NopCtx::new(
+            c,
+            1u64 << 48,
+            itt,
+            cmd_sn,
+            exp_stat_sn,
+            NopOutRequest::DEFAULT_TAG,
+        )
+    })
+    .await
+    .context("NOP after recovery failed")?;
+
+    let after = pool
+        .sessions
+        .get(&tsih)
+        .context("missing session after recovery")?
+        .conns
+        .get(&0)
+        .context("missing CID=0 after recovery")?
+        .conn
+        .clone();
+
+    assert!(before.is_poisoned(), "original connection must be poisoned");
+    assert!(
+        !Arc::ptr_eq(&before, &after),
+        "pool must replace poisoned connection"
+    );
+    assert!(
+        !after.is_poisoned(),
+        "replacement connection must remain healthy"
+    );
+
+    server.await??;
+    Ok(())
+}

--- a/tests/unit_tests/test_nop.rs
+++ b/tests/unit_tests/test_nop.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use iscsi_client_rs::{
     cfg::{cli::resolve_config_path, config::Config},
     models::{
-        common::{Builder, HEADER_LEN},
+        common::{BasicHeaderSegment, Builder, HEADER_LEN},
         data_fromat::{PduRequest, PduResponse},
         nop::{
             request::{NopOutRequest, NopOutRequestBuilder},
@@ -82,6 +82,35 @@ fn test_nop_in_parse() -> Result<()> {
 
     assert_eq!(hdr.stat_sn.get(), 3699214689);
     assert_eq!(hdr.exp_cmd_sn.get(), 191);
+
+    Ok(())
+}
+
+#[test]
+fn nop_payload_boundaries() -> Result<()> {
+    let cfg =
+        resolve_config_path("tests/config.yaml").and_then(Config::load_from_file)?;
+    let limit = cfg.login.flow.max_recv_data_segment_length as usize;
+
+    for len in [0, 1, 3, 4, limit - 1, limit] {
+        let header = NopOutRequestBuilder::new().initiator_task_tag(1);
+        let mut header_buf = [0u8; HEADER_LEN];
+        header.header.to_bhs_bytes(&mut header_buf)?;
+
+        let mut request = PduRequest::<NopOutRequest>::new_request(header_buf, &cfg);
+        request.append_data(&vec![0xa5; len]);
+        let (_, body) = request.build(limit)?;
+
+        assert_eq!(request.header_view()?.get_data_length_bytes(), len);
+        assert_eq!(body.len(), len.next_multiple_of(4));
+    }
+
+    let header = NopOutRequestBuilder::new().initiator_task_tag(2);
+    let mut header_buf = [0u8; HEADER_LEN];
+    header.header.to_bhs_bytes(&mut header_buf)?;
+    let mut oversized = PduRequest::<NopOutRequest>::new_request(header_buf, &cfg);
+    oversized.append_data(&vec![0; limit + 1]);
+    assert!(oversized.build(limit).is_err());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

This MR fixes TCP recovery after a poisoned connection and simplifies some of the client I/O code.

## Changes

- fixed `Pool` recovery so a poisoned connection can actually be recreated
- restored the previous `CID` entry if recovery login fails, so retries do not break with `CID not found`
- cleaned up duplicated `read/write` timeout and state checks in `ClientConnection`
- added integration tests for:
  - poisoned connection recovery
  - client fault cases
  - concurrent I/O
  - negative auth/login
  - I/O boundary cases

## Validation

Verified with unit tests and targeted integration tests, including recovery and boundary scenarios.
